### PR TITLE
Add shell linter

### DIFF
--- a/.github/workflows/shell-linter.yml
+++ b/.github/workflows/shell-linter.yml
@@ -1,0 +1,11 @@
+name: Shell linter 
+
+on: [push]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Lint check
+        uses: azohra/shell-linter@v0.2.0

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -38,8 +38,8 @@ echo "--------------------------------------------------------------------------
 
 builddir=$1
 shift
-alltags=$*
 basetag=$1
+alltags=$*
 
 project=$(basename "$currentdir")
 

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -38,8 +38,9 @@ echo "--------------------------------------------------------------------------
 
 builddir=$1
 shift
+# shellcheck disable=SC2124
+alltags=$@
 basetag=$1
-alltags=$*
 
 project=$(basename "$currentdir")
 

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -4,7 +4,7 @@ set -e
 
 currentdir=$(pwd)
 
-cd `dirname "$0"`
+cd "$(dirname "$0")"
 
 # Checking number of arguments
 
@@ -17,6 +17,7 @@ fi
 
 echo "-------------------------------------------------------------------------------------------"
 
+# shellcheck disable=SC2153
 docker_organization=$DOCKER_ORGANIZATION
 if [ -z "$docker_organization" ]; then
   echo "  No DOCKER_ORGANIZATION set. Please provde"
@@ -26,6 +27,7 @@ echo "Docker organization: $docker_organization"
 
 # Checking GITHUB_ORGANIZATION environment variable
 
+# shellcheck disable=SC2153
 github_organization=$GITHUB_ORGANIZATION
 if [ -z "$github_organization" ]; then
   echo "  No GITHUB_ORGANIZATION set. Using the DOCKER_ORGANIZATION ( $docker_organization ) instead."
@@ -36,21 +38,18 @@ echo "--------------------------------------------------------------------------
 
 builddir=$1
 shift
-alltags=$@
+alltags=$*
 basetag=$1
-shift
-tags=$@
 
-project=`basename $currentdir`
+project=$(basename "$currentdir")
 
 commitsha=${GITHUB_SHA}
 if [ -z "$GITHUB_SHA" ]; then
   echo "  No GITHUB_SHA set. Try to get it myself with git."
-  commitsha=`git rev-parse --verify HEAD`
+  commitsha=$(git rev-parse --verify HEAD)
 fi
 
-cd $currentdir
-cd $builddir
+cd "$builddir"
 
 echo "Building docker image: $builddir with tag: $basetag"
 echo "-------------------------------------------------------------------------------------------"
@@ -58,13 +57,13 @@ echo "--------------------------------------------------------------------------
 echo "$alltags" > TAGS
 echo "https://github.com/$github_organization/$project/tree/$commitsha" > REPO
 
-docker build . -t $docker_organization/$basetag
+docker build . -t "$docker_organization"/"$basetag"
 
 echo "-------------------------------------------------------------------------------------------"
 while test ${#} -gt 0
 do
   echo "Tagging $docker_organization/$basetag as $docker_organization/$1"
-  docker tag $docker_organization/$basetag $docker_organization/$1
+  docker tag "$docker_organization"/"$basetag" "$docker_organization"/"$1"
   shift
 done
 echo "============================================================================================"

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -15,7 +15,7 @@ fi
 
 # Checking DOCKER_ORGANIZATION environment variable 
 
-echo "-------------------------------------------------------------------------------------------"
+echo "--------------------------------------------------------------------------------------------"
 
 # shellcheck disable=SC2153
 docker_organization=$DOCKER_ORGANIZATION
@@ -34,13 +34,14 @@ if [ -z "$github_organization" ]; then
   github_organization=$docker_organization
 fi
 echo "Github organization: $github_organization"
-echo "-------------------------------------------------------------------------------------------"
+echo "--------------------------------------------------------------------------------------------"
 
 builddir=$1
 shift
-# shellcheck disable=SC2124
-alltags=$@
-basetag=$1
+alltags=$*
+IFS=' '
+read -ra tags <<< "$alltags"
+basetag=${tags[0]}
 
 project=$(basename "$currentdir")
 
@@ -53,19 +54,18 @@ fi
 cd "$builddir"
 
 echo "Building docker image: $builddir with tag: $basetag"
-echo "-------------------------------------------------------------------------------------------"
+echo "--------------------------------------------------------------------------------------------"
 
 echo "$alltags" > TAGS
 echo "https://github.com/$github_organization/$project/tree/$commitsha" > REPO
 
 docker build . -t "$docker_organization"/"$basetag"
 
-echo "-------------------------------------------------------------------------------------------"
-while test ${#} -gt 0
+echo "--------------------------------------------------------------------------------------------"
+for tag in "${tags[@]:1}"
 do
-  echo "Tagging $docker_organization/$basetag as $docker_organization/$1"
-  docker tag "$docker_organization"/"$basetag" "$docker_organization"/"$1"
-  shift
+  echo "Tagging $docker_organization/$basetag as $docker_organization/$tag"
+  docker tag "$docker_organization"/"$basetag" "$docker_organization"/"$tag"
 done
 echo "============================================================================================"
 echo "Finished building docker images: $builddir"

--- a/docker_build_and_push.sh
+++ b/docker_build_and_push.sh
@@ -14,16 +14,17 @@ fi
 
 ./docker_build.sh "$@"
 
+echo "Check if we need to push the docker images to docker hub:"
 echo "PUSH_BRANCH: $PUSH_BRANCH"
 echo "GITHUB_REF: $GITHUB_REF"
 
 if [[ "$GITHUB_REF" = "refs/heads/$PUSH_BRANCH" ]]
 then
-    echo "Matches"
-    echo "run docker_push"
+    echo "Matches: start pushing"
     ./docker_push.sh "$@"
 else
     echo "Do not match: $GITHUB_REF != refs/heads/$PUSH_BRANCH"
+    echo "No need to push the images to docker hub."
     exit 0
 fi
 

--- a/docker_build_and_push.sh
+++ b/docker_build_and_push.sh
@@ -3,8 +3,8 @@
 set -e
 
 help() { 
-  echo "This script requires two arguments, directory with the Docker file and the Docker tag.\n"
-  echo -e "Usages: "`basename "$0"` "<docker-file-directory> <tag>"
+  echo "This script requires two arguments, directory with the Docker file and the Docker tag."
+  echo "Usages: $(basename "$0") <docker-file-directory> <tag>"
 } 
 
 if [ "$#" -lt 2 ]; then
@@ -12,7 +12,7 @@ if [ "$#" -lt 2 ]; then
   exit 1
 fi
 
-./docker_build.sh $@
+./docker_build.sh "$@"
 
 echo "PUSH_BRANCH: $PUSH_BRANCH"
 echo "GITHUB_REF: $GITHUB_REF"
@@ -21,7 +21,7 @@ if [[ "$GITHUB_REF" = "refs/heads/$PUSH_BRANCH" ]]
 then
     echo "Matches"
     echo "run docker_push"
-    ./docker_push.sh $@
+    ./docker_push.sh "$@"
 else
     echo "Do not match: $GITHUB_REF != refs/heads/$PUSH_BRANCH"
     exit 0

--- a/docker_push.sh
+++ b/docker_push.sh
@@ -14,9 +14,10 @@ fi
 
 builddir=$1
 shift
-basetag=$1
-shift
-
+alltags=$*
+IFS=' '
+read -ra tags <<< "$alltags"
+basetag=${tags[0]}
 
 if [ -z "$DOCKER_PASSWORD" ]; then
   echo "  No DOCKER_PASSWORD set. Please provde"
@@ -29,17 +30,16 @@ if [ -z "$DOCKER_USERNAME" ]; then
 fi
 
 echo "Login to docker"
-echo "-------------------------------------------------------------------------"
+echo "--------------------------------------------------------------------------------------------"
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
 echo "Pushing $docker_organization/$basetag"
 docker push "$docker_organization"/"$basetag"
 
-while test ${#} -gt 0
+for tag in "${tags[@]:1}"
 do
-  echo "Pushing $docker_organization/$1"
-  docker push "$docker_organization"/"$1"
-  shift
+  echo "Pushing $docker_organization/$tag"
+  docker push "$docker_organization"/"$tag"
 done
 echo "============================================================================================"
 echo "Finished pushing docker images: $builddir"

--- a/docker_push.sh
+++ b/docker_push.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-cd `dirname "$0"`
+cd "$(dirname "$0")"
+
+# shellcheck disable=SC2153
 docker_organization=$DOCKER_ORGANIZATION
 
 if [ "$#" -lt 2 ]; then
@@ -14,7 +16,6 @@ builddir=$1
 shift
 basetag=$1
 shift
-tags=$@
 
 
 if [ -z "$DOCKER_PASSWORD" ]; then
@@ -32,16 +33,14 @@ echo "-------------------------------------------------------------------------"
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
 echo "Pushing $docker_organization/$basetag"
-docker push $docker_organization/$basetag
+docker push "$docker_organization"/"$basetag"
 
 while test ${#} -gt 0
 do
   echo "Pushing $docker_organization/$1"
-  docker push $docker_organization/$1
+  docker push "$docker_organization"/"$1"
   shift
 done
 echo "============================================================================================"
 echo "Finished pushing docker images: $builddir"
 echo "============================================================================================"
-
-

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,5 +9,5 @@ echo "push branch: $3"
 export PUSH_BRANCH=$3
 
 cd /
-./docker_build_and_push.sh /github/workspace/$1 $2
+./docker_build_and_push.sh /github/workspace/"$1" "$2"
 


### PR DESCRIPTION
# Purpose
This PR will add a shell-linter github action.

## Side-effect
Obviously this introduced some shellcheck issues, so this PR also fixes the problems.

# To Squash or not to Squash
Commits can be squashed since it is a logical step to put in one commit.

# Tested
- branch tested in: https://github.com/JeroenKnoops/test-docker-ci-script-ga/runs/508884850?check_suite_focus=true
- master with push test in: https://github.com/JeroenKnoops/test-docker-ci-script-ga/runs/508885571?check_suite_focus=true (fails, but only because of missing PASSWORD to push. I've tested it locally. The fixes are working)

