### PR TITLE
feat: remove hard coded paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,11 @@ LABEL "com.github.actions.description"="Builds docker images and publish master"
 LABEL "com.github.actions.icon"="terminal"
 LABEL "com.github.actions.color"="gray-dark"
 
-COPY LICENSE.md README.md /
+ENV FOREST_DIR=/forest
+RUN mkdir -p ${FOREST_DIR}
 
-COPY docker_build.sh docker_push.sh docker_build_and_push.sh update_readme.sh /
+COPY LICENSE.md README.md ${FOREST_DIR}/
+COPY docker_build.sh docker_push.sh docker_build_and_push.sh update_readme.sh ${FOREST_DIR}/
+COPY entrypoint.sh /
 
-COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-cd "$(dirname "$0")"
-
 # Checking number of arguments
 
 if [ "$#" -lt 3 ]; then
@@ -11,7 +9,7 @@ if [ "$#" -lt 3 ]; then
   exit 1
 fi
 
-# Checking DOCKER_ORGANIZATION environment variable 
+# Checking DOCKER_ORGANIZATION environment variable
 
 echo "--------------------------------------------------------------------------------------------"
 
@@ -31,7 +29,6 @@ fi
 
 echo "docker_registry_prefix: $docker_registry_prefix"
 
-
 # Checking GITHUB_ORGANIZATION environment variable
 
 # shellcheck disable=SC2153
@@ -49,7 +46,7 @@ imagename=$1
 shift
 alltags=$*
 IFS=' '
-read -ra tags <<< "$alltags"
+read -ra tags <<<"$alltags"
 basetag=${tags[0]}
 
 project=${GITHUB_REPOSITORY}
@@ -60,22 +57,24 @@ if [ -z "$GITHUB_SHA" ]; then
   commitsha=$(git rev-parse --verify HEAD)
 fi
 
+echo $PWD
+echo "ttttttt"
+ls -la
 cd "$builddir"
 
 echo "Building docker image: $builddir with name: $imagename/$basetag"
 echo "--------------------------------------------------------------------------------------------"
 
 echo "tags: $alltags"
-echo "$alltags" > TAGS
+echo "$alltags" >TAGS
 
 echo "repo: https://github.com/$project/tree/$commitsha"
-echo "https://github.com/$project/tree/$commitsha" > REPO
+echo "https://github.com/$project/tree/$commitsha" >REPO
 
 docker build . -t "$docker_registry_prefix"/"$imagename":"$basetag"
 
 echo "--------------------------------------------------------------------------------------------"
-for tag in "${tags[@]:1}"
-do
+for tag in "${tags[@]:1}"; do
   echo "Tagging $docker_registry_prefix/$imagename:$basetag as $docker_registry_prefix/$imagename:$tag"
   docker tag "$docker_registry_prefix"/"$imagename":"$basetag" "$docker_registry_prefix"/"$imagename":"$tag"
 done

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -57,9 +57,6 @@ if [ -z "$GITHUB_SHA" ]; then
   commitsha=$(git rev-parse --verify HEAD)
 fi
 
-echo $PWD
-echo "ttttttt"
-ls -la
 cd "$builddir"
 
 echo "Building docker image: $builddir with name: $imagename/$basetag"

--- a/docker_build_and_push.sh
+++ b/docker_build_and_push.sh
@@ -2,29 +2,27 @@
 
 set -e
 
-help() { 
+help() {
   echo "This script requires three arguments, directory with the Docker file, Docker image name and the Docker tag."
   echo "Usages: $(basename "$0") <docker-file-directory> <docker-image-name> <tag>"
-} 
+}
 
 if [ "$#" -lt 3 ]; then
   help
   exit 1
 fi
 
-./docker_build.sh "$@"
+${FOREST_DIR}/docker_build.sh "$@"
 
 echo "Check if we need to push the docker images to docker hub:"
 echo "PUSH_BRANCH: $PUSH_BRANCH"
 echo "GITHUB_REF: $GITHUB_REF"
 
-if [[ "$GITHUB_REF" = "refs/heads/$PUSH_BRANCH" ]]
-then
-    echo "Matches: start pushing"
-    ./docker_push.sh "$@"
+if [[ "$GITHUB_REF" = "refs/heads/$PUSH_BRANCH" ]]; then
+  echo "Matches: start pushing"
+  ${FOREST_DIR}/docker_push.sh "$@"
 else
-    echo "Do not match: $GITHUB_REF != refs/heads/$PUSH_BRANCH"
-    echo "No need to push the images to docker hub."
-    exit 0
+  echo "Do not match: $GITHUB_REF != refs/heads/$PUSH_BRANCH"
+  echo "No need to push the images to docker hub."
+  exit 0
 fi
-

--- a/docker_push.sh
+++ b/docker_push.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-cd "$(dirname "$0")"
-
 # shellcheck disable=SC2153
 docker_organization=$DOCKER_ORGANIZATION
 
@@ -32,7 +30,7 @@ imagename=$1
 shift
 alltags=$*
 IFS=' '
-read -ra tags <<< "$alltags"
+read -ra tags <<<"$alltags"
 basetag=${tags[0]}
 
 if [ -z "$DOCKER_PASSWORD" ]; then
@@ -52,8 +50,7 @@ echo "$DOCKER_PASSWORD" | docker login "$DOCKER_REGISTRY" -u "$DOCKER_USERNAME" 
 echo "Pushing $docker_registry_prefix/$imagename:$basetag"
 docker push "$docker_registry_prefix"/"$imagename":"$basetag"
 
-for tag in "${tags[@]:1}"
-do
+for tag in "${tags[@]:1}"; do
   echo "Pushing $docker_registry_prefix/$imagename:$tag"
   docker push "$docker_registry_prefix"/"$imagename":"$tag"
 done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,4 @@ echo "push branch    : $4"
 
 export PUSH_BRANCH=$4
 
-cd /
-./docker_build_and_push.sh /github/workspace/"$1" "$2" "$3"
-
+./docker_build_and_push.sh "$1" "$2" "$3"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,4 +7,4 @@ echo "push branch    : $4"
 
 export PUSH_BRANCH=$4
 
-./docker_build_and_push.sh "$1" "$2" "$3"
+${FOREST_DIR}/docker_build_and_push.sh "$1" "$2" "$3"


### PR DESCRIPTION
No need to do path magic and hard coded paths for github actions. A containerized action will start in the the root fo the repo. I have removed the hard coded paths. Added the forest script to a forest dir.