### PR TITLE
Docker push when the action trigger is a pull_request

### DIFF
--- a/docker_build_and_push.sh
+++ b/docker_build_and_push.sh
@@ -17,15 +17,25 @@ fi
 echo "Check if we need to push the docker images to docker hub:"
 # shellcheck disable=SC2153
 echo "Push branches: $PUSH_BRANCHES"
+echo "GITHUB_EVENT_NAME: $GITHUB_EVENT_NAME"
 echo "GITHUB_REF: $GITHUB_REF"
+echo "GITHUB_HEAD_REF: $GITHUB_HEAD_REF"
 
 read -ra push_branches <<< "$PUSH_BRANCHES"
 
 for branch in "${push_branches[@]}"; do
+  if [[ "$GITHUB_EVENT_NAME" = "pull_request" ]]; then
+    if [[ "$GITHUB_HEAD_REF" = "$branch" ]]; then
+      echo "Matches: start pushing"
+      "${FOREST_DIR}"/docker_push.sh "$@"
+      exit 0
+    fi
+  else
   if [[ "$GITHUB_REF" = "refs/heads/${branch}" ]]; then
-    echo "Matches: start pushing"
-    "${FOREST_DIR}"/docker_push.sh "$@"
-    exit 0
+      echo "Matches: start pushing"
+      "${FOREST_DIR}"/docker_push.sh "$@"
+      exit 0
+    fi
   fi
 done
 

--- a/docker_build_and_push.sh
+++ b/docker_build_and_push.sh
@@ -20,12 +20,13 @@ echo "Push branches: $PUSH_BRANCHES"
 echo "GITHUB_EVENT_NAME: $GITHUB_EVENT_NAME"
 echo "GITHUB_REF: $GITHUB_REF"
 echo "GITHUB_HEAD_REF: $GITHUB_HEAD_REF"
+echo "GITHUB_BASE_REF: $GITHUB_BASE_REF"
 
 read -ra push_branches <<< "$PUSH_BRANCHES"
 
 for branch in "${push_branches[@]}"; do
   if [[ "$GITHUB_EVENT_NAME" = "pull_request" ]]; then
-    if [[ "$GITHUB_HEAD_REF" = "$branch" ]]; then
+    if [[ "$GITHUB_BASE_REF" = "$branch" ]]; then
       echo "Matches: start pushing"
       "${FOREST_DIR}"/docker_push.sh "$@"
       exit 0


### PR DESCRIPTION
When a pull request triggers an action, the docker image is not pushed to artifactory because $GITHUB_REF is something like "refs/pull/187/merge". In this case, the branch name is stored in $GITHUB_BASE_REF, which should be used to compare with the defined push-branches. 