### PR TITLE
Add base directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
   push-branches:
     description: 'Specifies branches to push, separated by a space'
     default: 'master main'
+  base-dir:
+    description: 'Base directory to perform the docker build'
+    default: '.'
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -27,4 +30,5 @@ runs:
     - ${{ inputs.image-name }}
     - ${{ inputs.tags }}
     - ${{ inputs.push-branches }}
+    - ${{ inputs.base-dir }}
     - ${{ inputs.push-branch }}

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -11,7 +11,7 @@ function expandDockerfile {
 # Checking number of arguments
 
 if [ "$#" -lt 4 ]; then
-  echo "You need to provide a directory with a Dockerfile in it, Docker image name, one or more tags and the base-dir."
+  echo "You need to provide a directory with a Dockerfile in it, Docker image name, the base-dir and one or more tags."
   exit 1
 fi
 
@@ -46,21 +46,24 @@ fi
 echo "Github organization: $github_organization"
 echo "--------------------------------------------------------------------------------------------"
 
-echo "Switching to $4"
-echo "--------------------------------------------------------------------------------------------"
-cd $4
 
 dockerfile=$1
-
-dockerfilepath=$(expandDockerfile "$dockerfile")
-
 shift
 imagename=$1
 shift
+basedir=$1
+shift
 alltags=$*
+
 IFS=' '
 read -ra tags <<<"$alltags"
 basetag=${tags[0]}
+
+echo "Switching to $basedir"
+echo "--------------------------------------------------------------------------------------------"
+cd $basedir
+
+dockerfilepath=$(expandDockerfile "$dockerfile")
 
 project=${GITHUB_REPOSITORY}
 

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -10,8 +10,8 @@ function expandDockerfile {
 
 # Checking number of arguments
 
-if [ "$#" -lt 3 ]; then
-  echo "You need to provide a directory with a Dockerfile in it, Docker image name and one or more tags."
+if [ "$#" -lt 4 ]; then
+  echo "You need to provide a directory with a Dockerfile in it, Docker image name, one or more tags and the base-dir."
   exit 1
 fi
 
@@ -45,6 +45,10 @@ if [ -z "$github_organization" ]; then
 fi
 echo "Github organization: $github_organization"
 echo "--------------------------------------------------------------------------------------------"
+
+echo "Switching to $4"
+echo "--------------------------------------------------------------------------------------------"
+cd $4
 
 dockerfile=$1
 

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -61,7 +61,7 @@ basetag=${tags[0]}
 
 echo "Switching to $basedir"
 echo "--------------------------------------------------------------------------------------------"
-cd $basedir
+cd "$basedir"
 
 dockerfilepath=$(expandDockerfile "$dockerfile")
 

--- a/docker_build_and_push.sh
+++ b/docker_build_and_push.sh
@@ -4,10 +4,10 @@ set -e
 
 help() {
   echo "This script requires three arguments, directory with the Docker file, Docker image name and the Docker tag."
-  echo "Usages: $(basename "$0") <docker-file-directory> <docker-image-name> <tag>"
+  echo "Usages: $(basename "$0") <docker-file-directory> <docker-image-name> <tag> <base-dir>"
 }
 
-if [ "$#" -lt 3 ]; then
+if [ "$#" -lt 4 ]; then
   help
   exit 1
 fi

--- a/docker_build_and_push.sh
+++ b/docker_build_and_push.sh
@@ -4,7 +4,7 @@ set -e
 
 help() {
   echo "This script requires three arguments, directory with the Docker file, Docker image name and the Docker tag."
-  echo "Usages: $(basename "$0") <docker-file-directory> <docker-image-name> <tag> <base-dir>"
+  echo "Usages: $(basename "$0") <docker-file-directory> <docker-image-name> <base-dir> <tag>"
 }
 
 if [ "$#" -lt 4 ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,14 +4,15 @@ echo "dockerfile     : $1"
 echo "image name     : $2"
 echo "tags           : $3"
 echo "push branches  : $4"
-echo "push branch    : $5"
+echo "base dir       : $5"
+echo "push branch    : $6"
 
-if [ -z "$5" ]
+if [ -z "$6" ]
   then
     export PUSH_BRANCHES="$4"
   else
     echo "DEPRECATION WARNING: push-branch will be replaced by push-branches"
-    export PUSH_BRANCHES="$5"
+    export PUSH_BRANCHES="$6"
 fi
 
-"${FOREST_DIR}"/docker_build_and_push.sh "$1" "$2" "$3"
+"${FOREST_DIR}"/docker_build_and_push.sh "$1" "$2" "$3" "$5"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,4 +15,4 @@ if [ -z "$6" ]
     export PUSH_BRANCHES="$6"
 fi
 
-"${FOREST_DIR}"/docker_build_and_push.sh "$1" "$2" "$3" "$5"
+"${FOREST_DIR}"/docker_build_and_push.sh "$1" "$2" "$5" "$3"


### PR DESCRIPTION
Implemented added the option to add a base directory.

Now you can specify an optional `base-dir`. This will change the root directory from where a docker build is triggered.

## Examples

### Previously
``` 
- name: Build Docker Images with scancode      
  uses: philips-software/docker-ci-scripts@v3.2.1      
  with:        
     dockerfile: 2/scancode/tern/docker/Dockerfile.scancode        
     image-name: tern        
     tags: 2-scancode 2.6-scancode 2.6.1-scancode      
```

### After this fix
``` 
- name: Build Docker Images with scancode      
  uses: philips-software/docker-ci-scripts@v3.2.1      
  with:        
     base-dir: 2/scancode/tern
     dockerfile: docker/Dockerfile.scancode        
     image-name: tern        
     tags: 2-scancode 2.6-scancode 2.6.1-scancode      
```

## Why
Sometimes you want to include files in the build, for example `entrypoint.sh` and when using `docker-ci-scripts` in repositories with submodules, the paths to the file in the Dockerfile are not correct when building the docker image from the root of the project. So unless you're not using submodules and not add files in your docker images, you don't need to specify the base-dir from where docker is building the image... but if you do need to add files... you should use `base-dir`

## Related issue
Closes #52 

## Tested in
Tested this branch in: https://github.com/philips-software/docker-tern/runs/2696141672?check_suite_focus=true