### PR TITLE
Add SLSA Provenance feature

### DIFF
--- a/.github/workflows/shell-linter.yml
+++ b/.github/workflows/shell-linter.yml
@@ -9,3 +9,5 @@ jobs:
       - uses: actions/checkout@v2
       - name: Lint check
         uses: azohra/shell-linter@v0.6.0
+        with:
+          exclude-paths: "bin/install_cosign.sh"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM docker:20.10.12-git
 
 RUN apk update && apk add \
-    bash \
-    jq \
-    curl \
-    wget \
-    git
+      bash \
+      jq \
+      curl \
+      wget \
+      git
+
 
 LABEL "name"="docker-build"
 LABEL "maintainer"="Jeroen Knoops <jeroen.knoops@philips.com>"
@@ -22,5 +23,12 @@ RUN mkdir -p ${FOREST_DIR}
 COPY LICENSE.md README.md ${FOREST_DIR}/
 COPY docker_build.sh docker_push.sh docker_build_and_push.sh update_readme.sh container_digest.sh ${FOREST_DIR}/
 COPY entrypoint.sh /
+
+RUN mkdir -p /scripts
+ADD bin/install_cosign.sh /scripts
+RUN chmod +x /scripts/install_cosign.sh
+
+ADD bin/install_slsa_provenance.sh /scripts
+RUN chmod +x /scripts/install_slsa_provenance.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This action will build a docker container from a given directory.
 - You can specify for which branch it should push it a docker registry ( `docker.io` by default ). 
 - Each docker container contains information about the exact context in which the container is build.
 - When pushing to docker.io, the description is updated with the `readme.md` file.
+- If required, a provenance file is created according to the [SLSA.dev](https://slsa.dev) specifications. 
 
 ## Contents
 
@@ -27,7 +28,7 @@ This action will build a docker container from a given directory.
 <!-- action-docs-description -->
 ## Description
 
-Builds docker images and publish them on request
+Builds docker images and publish them on request.
 
 
 <!-- action-docs-description -->
@@ -122,6 +123,24 @@ This action is an `docker` action.
           image-name: image-name-here
           tags: latest 0.1
           push-branches: main develop
+        env:
+          DOCKER_USERNAME: ${{ github.actor }}
+          DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_REGISTRY: ghcr.io/organization-here
+          GITHUB_ORGANIZATION: organization-here
+```
+
+#### With SLSA Provenance:
+
+```
+      - name: Build Docker Images
+        uses: philips-software/docker-ci-scripts@v3.3.2
+        with:
+          dockerfile: .
+          image-name: image-name-here
+          tags: latest 0.1
+          push-branches: main develop
+          slsa-provenance: true
         env:
           DOCKER_USERNAME: ${{ github.actor }}
           DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,17 @@ inputs:
   base-dir:
     description: 'Base directory to perform the build'
     default: '.'
+  slsa-provenance:
+    description: 'Create SLSA Provenance json'
+    required: false
+  github_context:
+    description: 'internal (do not set): the "github" context object in json'
+    required: true
+    default: ${{ toJSON(github) }}
+  runner_context:
+    description: 'internal (do not set): the "runner" context object in json'
+    required: true
+    default: ${{ toJSON(runner) }}
 outputs:
   container-digest:
     description: 'Container digest. Can be used for generating provenance and signing.'
@@ -29,6 +40,8 @@ outputs:
     description: 'Container tags. Can be used for generating provenance and signing.'
   push-indicator:
     description: 'Is set to true when containers have been pushed to the container repository'
+  slsa-provenance-file:
+    description: 'SLSA provenance file if created'
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -39,3 +52,7 @@ runs:
     - ${{ inputs.push-branches }}
     - ${{ inputs.base-dir }}
     - ${{ inputs.push-branch }}
+  env:
+    SLSA_PROVENANCE: ${{ inputs.slsa-provenance }}
+    GITHUB_CONTEXT: ${{ inputs.github_context }}
+    RUNNER_CONTEXT: ${{ inputs.runner_context }}

--- a/bin/install_cosign.sh
+++ b/bin/install_cosign.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+
+COSIGN_RELEASE=v1.4.1
+INSTALL_DIR=$HOME/.cosign
+
+RUNNER_OS=$(uname)
+# RUNNER_ARCH=$(uname -m)
+RUNNER_ARCH=X64
+
+#cosign install script
+shopt -s expand_aliases
+if [ -z "$NO_COLOR" ]; then
+  alias log_info="echo -e \"\033[1;32mINFO\033[0m:\""
+  alias log_error="echo -e \"\033[1;31mERROR\033[0m:\""
+else
+  alias log_info="echo \"INFO:\""
+  alias log_error="echo \"ERROR:\""
+fi
+set -e
+shaprog() {
+  case ${RUNNER_OS} in
+    Linux)
+      sha256sum $1 | cut -d' ' -f1
+      ;;
+    macOS)
+      shasum -a256 $1 | cut -d' ' -f1
+      ;;
+    Windows)
+      powershell -command "(Get-FileHash $1 -Algorithm SHA256 | Select-Object -ExpandProperty Hash).ToLower()"
+      ;;
+    *)
+      log_error "unsupported OS ${RUNNER_OS}}"
+      exit 1
+      ;;
+  esac
+}
+
+bootstrap_version='v1.4.1'    
+bootstrap_linux_amd64_sha='08ba779a4e6ff827079abed1a6d1f0a0d9e48aea21f520ddeb42ff912f59d268'
+bootstrap_linux_arm_sha='d13f12dea3b65ec4bcd25fe23d35772f7b0b5997dba14947ce242e1260b3a15d'
+bootstrap_linux_arm64_sha='b0c02b607e722b9d2b1807f6efb73042762e77391c51c8948710e7f571ceaa73'
+bootstrap_darwin_amd64_sha='0908ffd3ceea5534c27059e30276094d63ed9339c2bf75e38e3d88d0a34502f3'
+bootstrap_darwin_arm64_sha='f8162aba987e1afddb20a672e47fb070ec6bf1547f65f23159e0f4a61e4ea673'
+bootstrap_windows_amd64_sha='408557d35b0158590c1978d72cf5079fc299b3f0315f3ece259c6c0f159a079b'
+trap "popd >/dev/null" EXIT
+mkdir -p ${INSTALL_DIR}
+pushd ${INSTALL_DIR} > /dev/null
+case ${RUNNER_OS} in
+  Linux)
+    case ${RUNNER_ARCH} in
+      X64)
+        bootstrap_filename='cosign-linux-amd64'
+        bootstrap_sha=${bootstrap_linux_amd64_sha}
+        desired_cosign_filename='cosign-linux-amd64'
+        # v0.6.0 had different filename structures from all other releases
+        if [[ ${COSIGN_RELEASE} == 'v0.6.0' ]]; then
+          desired_cosign_filename='cosign_linux_amd64'
+          desired_cosign_v060_signature='cosign_linux_amd64_0.6.0_linux_amd64.sig'
+        fi
+        ;;
+      
+      ARM)
+        bootstrap_filename='cosign-linux-arm'
+        bootstrap_sha=${bootstrap_linux_arm_sha}
+        desired_cosign_filename='cosign-linux-arm'
+        if [[ ${COSIGN_RELEASE} == 'v0.6.0' ]]; then
+          log_error "linux-arm build not available at v0.6.0"
+          exit 1
+        fi
+        ;;
+      
+      ARM64)
+        bootstrap_filename='cosign-linux-arm64'
+        bootstrap_sha=${bootstrap_linux_arm64_sha}
+        desired_cosign_filename='cosign-linux-amd64'
+        if [[ ${COSIGN_RELEASE} == 'v0.6.0' ]]; then
+          log_error "linux-arm64 build not available at v0.6.0"
+          exit 1
+        fi
+        ;;
+      
+      *)
+        log_error "unsupported architecture ${RUNNER_ARCH}"
+        exit 1
+        ;;
+    esac
+    ;;
+  
+  macOS)
+    case ${RUNNER_ARCH} in
+      X64)
+        bootstrap_filename='cosign-darwin-amd64'
+        bootstrap_sha=${bootstrap_darwin_amd64_sha}
+        desired_cosign_filename='cosign-darwin-amd64'
+        # v0.6.0 had different filename structures from all other releases
+        if [[ ${COSIGN_RELEASE} == 'v0.6.0' ]]; then
+          desired_cosign_filename='cosign_darwin_amd64'
+          desired_cosign_v060_signature='cosign_darwin_amd64_0.6.0_darwin_amd64.sig'
+        fi
+        ;;
+      
+      ARM64)
+        bootstrap_filename='cosign-darwin-arm64'
+        bootstrap_sha=${bootstrap_darwin_arm64_sha}
+        desired_cosign_filename='cosign-darwin-arm64'
+        # v0.6.0 had different filename structures from all other releases
+        if [[ ${COSIGN_RELEASE} == 'v0.6.0' ]]; then
+          desired_cosign_filename='cosign_darwin_arm64'
+          desired_cosign_v060_signature='cosign_darwin_arm64_0.6.0_darwin_arm64.sig'
+        fi
+        ;;
+      
+      *)
+        log_error "unsupported architecture $arch"
+        exit 1
+        ;;
+    esac
+    ;;
+  Windows)
+    case ${RUNNER_ARCH} in
+      X64)
+        bootstrap_filename='cosign-windows-amd64.exe'
+        bootstrap_sha=${bootstrap_windows_amd64_sha}
+        desired_cosign_filename='cosign-windows-amd64.exe'
+        # v0.6.0 had different filename structures from all other releases
+        if [[ ${COSIGN_RELEASE} == 'v0.6.0' ]]; then
+          desired_cosign_filename='cosign_windows_amd64.exe'
+          desired_cosign_v060_signature='cosign_windows_amd64_0.6.0_windows_amd64.exe.sig'
+        fi
+        ;;
+      *)
+        log_error "unsupported architecture $arch"
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    log_error "unsupported architecture $arch"
+    exit 1
+    ;;
+esac
+expected_bootstrap_version_digest=${bootstrap_sha}
+log_info "Downloading bootstrap version '${bootstrap_version}' of cosign to verify version to be installed...\n      https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename}"
+curl -sL https://storage.googleapis.com/cosign-releases/${bootstrap_version}/${bootstrap_filename} -o cosign
+shaBootstrap=$(shaprog cosign);
+if [[ $shaBootstrap != ${expected_bootstrap_version_digest} ]]; then
+  log_error "Unable to validate cosign version: '${COSIGN_RELEASE}'"
+  exit 1
+fi
+chmod +x cosign
+# If the bootstrap and specified `cosign` releases are the same, we're done.
+if [[ ${COSIGN_RELEASE} == ${bootstrap_version} ]]; then
+  log_info "bootstrap version successfully verified and matches requested version so nothing else to do"
+  exit 0
+fi
+semver='^v([0-9]+\.){0,2}(\*|[0-9]+)$'
+if [[ ${COSIGN_RELEASE} =~ $semver ]]; then
+  log_info "Custom cosign version '${COSIGN_RELEASE}' requested"
+else
+  log_error "Unable to validate requested cosign version: '${COSIGN_RELEASE}'"
+  exit 1
+fi
+# Download custom cosign
+log_info "Downloading platform-specific version '${COSIGN_RELEASE}' of cosign...\n      https://storage.googleapis.com/cosign-releases/${COSIGN_RELEASE}/${desired_cosign_filename}"
+curl -sL https://storage.googleapis.com/cosign-releases/${COSIGN_RELEASE}/${desired_cosign_filename} -o cosign_${COSIGN_RELEASE}
+shaCustom=$(shaprog cosign_${COSIGN_RELEASE});
+# same hash means it is the same release
+if [[ $shaCustom != $shaBootstrap ]]; then
+  if [[ ${COSIGN_RELEASE} == 'v0.6.0' && ${RUNNER_OS} == 'Linux' ]]; then
+    # v0.6.0's linux release has a dependency on `libpcsclite1`
+    log_info "Installing libpcsclite1 package if necessary..."
+    set +e
+    sudo dpkg -s libpcsclite1
+    if [ $? -eq 0 ]; then
+        log_info "libpcsclite1 package is already installed"
+    else
+         log_info "libpcsclite1 package is not installed, installing it now."
+         sudo apt-get update -q -q
+         sudo apt-get install -yq libpcsclite1
+    fi
+    set -e
+  fi
+  if [[ ${COSIGN_RELEASE} == 'v0.6.0' ]]; then
+    log_info "Downloading detached signature for platform-specific '${COSIGN_RELEASE}' of cosign...\n      https://github.com/sigstore/cosign/releases/download/${COSIGN_RELEASE}/${desired_cosign_v060_signature}"
+    curl -sL https://github.com/sigstore/cosign/releases/download/${COSIGN_RELEASE}/${desired_cosign_v060_signature} -o ${desired_cosign_filename}.sig
+  else
+    log_info "Downloading detached signature for platform-specific '${COSIGN_RELEASE}' of cosign...\n      https://github.com/sigstore/cosign/releases/download/${COSIGN_RELEASE}/${desired_cosign_filename}.sig"
+    curl -sLO https://github.com/sigstore/cosign/releases/download/${COSIGN_RELEASE}/${desired_cosign_filename}.sig
+  fi
+  if [[ ${COSIGN_RELEASE} < 'v0.6.0' ]]; then
+    RELEASE_COSIGN_PUB_KEY=https://raw.githubusercontent.com/sigstore/cosign/${COSIGN_RELEASE}/.github/workflows/cosign.pub
+  else
+    RELEASE_COSIGN_PUB_KEY=https://raw.githubusercontent.com/sigstore/cosign/${COSIGN_RELEASE}/release/release-cosign.pub
+  fi
+  log_info "Using bootstrap cosign to verify signature of desired cosign version"
+  ./cosign verify-blob --key $RELEASE_COSIGN_PUB_KEY --signature ${desired_cosign_filename}.sig cosign_${COSIGN_RELEASE}
+  rm cosign
+  mv cosign_${COSIGN_RELEASE} cosign
+  chmod +x cosign
+  export PATH=${INSTALL_DIR}:$PATH
+  
+  log_info "Installation complete!"
+fi

--- a/bin/install_slsa_provenance.sh
+++ b/bin/install_slsa_provenance.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+SLSA_PROVENANCE_VERSION=0.5.0
+INSTALL_DIR=$HOME/.cosign
+
+function install_slsa_provenance {
+    case "$(uname -s)" in
+        Linux*)
+            machine=linux
+            shasum=sha256sum
+            ;;
+        Darwin*)
+            machine=macOS
+            shasum=shasum
+            ;;
+    esac
+
+    curl -qLO https://github.com/philips-labs/slsa-provenance-action/releases/download/v${SLSA_PROVENANCE_VERSION}/slsa-provenance_${SLSA_PROVENANCE_VERSION}_${machine}_amd64.tar.gz
+    curl -qLO https://github.com/philips-labs/slsa-provenance-action/releases/download/v${SLSA_PROVENANCE_VERSION}/checksums.txt
+    < checksums.txt grep slsa-provenance_${SLSA_PROVENANCE_VERSION}_${machine}_amd64.tar.gz | $shasum -c -
+
+    # shellcheck disable=SC2181
+    if [ $? != 0 ] ; then
+        echo Checksum does not match.
+        exit 1
+    fi
+
+    echo "INSTALL_DIR: ${INSTALL_DIR}"
+    mkdir -p "${INSTALL_DIR}"
+    tar -xf slsa-provenance_${SLSA_PROVENANCE_VERSION}_${machine}_amd64.tar.gz -C "${INSTALL_DIR}"
+    chmod +x "${INSTALL_DIR}"/slsa-provenance
+    echo "ls"
+    ls -lah "${INSTALL_DIR}"
+    rm -f slsa-provenance_${SLSA_PROVENANCE_VERSION}_${machine}_amd64.tar.gz checksums.txt
+}
+
+install_slsa_provenance
+export PATH=${INSTALL_DIR}:$PATH

--- a/bin/install_slsa_provenance.sh
+++ b/bin/install_slsa_provenance.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-SLSA_PROVENANCE_VERSION=0.5.0
-INSTALL_DIR=$HOME/.cosign
+SLSA_PROVENANCE_VERSION=0.5.1
+INSTALL_DIR=$HOME/.slsa_provenance
 
 function install_slsa_provenance {
     case "$(uname -s)" in
@@ -15,8 +15,8 @@ function install_slsa_provenance {
             ;;
     esac
 
-    curl -qLO https://github.com/philips-labs/slsa-provenance-action/releases/download/v${SLSA_PROVENANCE_VERSION}/slsa-provenance_${SLSA_PROVENANCE_VERSION}_${machine}_amd64.tar.gz
-    curl -qLO https://github.com/philips-labs/slsa-provenance-action/releases/download/v${SLSA_PROVENANCE_VERSION}/checksums.txt
+    curl -sSLO https://github.com/philips-labs/slsa-provenance-action/releases/download/v${SLSA_PROVENANCE_VERSION}/slsa-provenance_${SLSA_PROVENANCE_VERSION}_${machine}_amd64.tar.gz
+    curl -sSLO https://github.com/philips-labs/slsa-provenance-action/releases/download/v${SLSA_PROVENANCE_VERSION}/checksums.txt
     < checksums.txt grep slsa-provenance_${SLSA_PROVENANCE_VERSION}_${machine}_amd64.tar.gz | $shasum -c -
 
     # shellcheck disable=SC2181
@@ -25,12 +25,9 @@ function install_slsa_provenance {
         exit 1
     fi
 
-    echo "INSTALL_DIR: ${INSTALL_DIR}"
     mkdir -p "${INSTALL_DIR}"
     tar -xf slsa-provenance_${SLSA_PROVENANCE_VERSION}_${machine}_amd64.tar.gz -C "${INSTALL_DIR}"
     chmod +x "${INSTALL_DIR}"/slsa-provenance
-    echo "ls"
-    ls -lah "${INSTALL_DIR}"
     rm -f slsa-provenance_${SLSA_PROVENANCE_VERSION}_${machine}_amd64.tar.gz checksums.txt
 }
 

--- a/container_digest.sh
+++ b/container_digest.sh
@@ -61,3 +61,31 @@ echo "::set-output name=container-tags::${containertags}"
 echo "============================================================================================"
 echo "Finished getting docker digest and tags"
 echo "============================================================================================"
+
+if [ -n "${SLSA_PROVENANCE}" ]
+then
+  echo "Running SLSA Provenance"
+
+  encoded_github="$(echo "$GITHUB_CONTEXT" | base64 -w 0)"
+  encoded_runner="$(echo "$RUNNER_CONTEXT" | base64 -w 0)"
+
+  slsa-provenance generate container \
+    --github-context "$encoded_github" \
+    --runner-context "$encoded_runner" \
+    --repository "$docker_registry_prefix"/"$imagename" \
+    --digest "${containerdigest}" \
+    --tags "${containertags}"
+
+  echo "-------------------------------------------------------------------------------------------"
+  echo " provenance.json "
+  echo "-------------------------------------------------------------------------------------------"
+
+  cat provenance.json
+  echo
+
+  echo "::set-output name=slsa-provenance-file::provenance.json"
+
+  echo "============================================================================================"
+  echo "Finished getting SLSA Provenance"
+  echo "============================================================================================"
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,31 @@
 #!/bin/sh -l
 
+if [ -n "${SLSA_PROVENANCE}" ]
+then
+  echo "+ SLSA Provenance ---------"
+  echo "| Installing slsa provenance"
+  . $GITHUB_ACTION_PATH/scripts/install_slsa_provenance.sh
+  echo "| Show slsa provenance version"
+  slsa-provenance version
+  echo "| Finished installing slsa-provenance"
+  echo "- SLSA Provenance ---------"
+fi
+
+# For future extention.
+# 1) Attach SLSA_PROVENANCE json to docker image
+# 2) Sign docker image
+if [ -n "${COSIGN}" ]
+then
+  echo "+ Cosign ------------------"
+  echo "| Installing cosign"
+  $GITHUB_ACTION_PATH/scripts/install_cosign.sh
+  export PATH=${HOME}/.cosign:$PATH
+  echo "| Show cosign version"
+  cosign version
+  echo "| Finished installing cosign"
+  echo "- Cosign ------------------"
+fi
+
 echo "dockerfile     : $1"
 echo "image name     : $2"
 echo "tags           : $3"


### PR DESCRIPTION
This PR will add an extra option to generate a provenance file. 

# Usage
Add input `slsa-provenance: true` to generate a provenance file.

## Exampe workflow
```
- name: Build Docker Images
  id: docker
  uses: philips-software/docker-ci-scripts@v3.3.2
  with:
    dockerfile: .
    image-name: image-name-here
    tags: latest 0.1
    slsa-provenance: true
  env:
    DOCKER_USERNAME: ${{ github.actor }}
    DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
    DOCKER_REGISTRY: ghcr.io/organization-here
    GITHUB_ORGANIZATION: organization-here
```

The filename of the provenance file is given as an output. You can use that to upload the provenance file as artifact.

```
- name: Upload a Build Artifact
  uses: actions/upload-artifact@v2.3.1
  with:
    name: provenance
    path: ${{ steps.docker.outputs.slsa-provenance-file }}
    retention-days: 5
```

## Cosign
We're going to use Cosign to attach the provenance file to the docker image later. There are already parts of this change in this PR. I want to release this feature together with the cosign change, but I like PRs for one specific thing only.
The Cosign installation part is not used, so I want to keep that in this PR.

# Learn more

Learn more about provenance and Secure Software Supply Chain on:

- https://slsa.dev
- https://github.com/philips-labs/slsa-provenance-action

# Related issue
Part of #78
