### PR TITLE
Attach provenance to image

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ This action will build a docker container from a given directory.
 - When pushing to docker.io, the description is updated with the `readme.md` file.
 - If required, a provenance file is created according to the [SLSA.dev](https://slsa.dev) specifications. 
 
+In every docker container there are two files:
+* `TAGS` - contains all tags associated with this container at time it was build.
+* `REPO` - contains a link to the github repository with the commit sha.
+
 ## Contents
 
 * [Description](#description)
@@ -48,7 +52,6 @@ Builds docker images and publish them on request
 | runner_context | internal (do not set): the "runner" context object in json | `true` | ${{ toJSON(runner) }} |
 
 
-
 <!-- action-docs-inputs -->
 
 ## Environment variables
@@ -77,10 +80,21 @@ No need to put this in GitHub Secret vault. This will be public anyway.
 **Optional** Github organization. Defaults to DOCKER_ORGANIZATION. Example: `philips-software` 
 No need to put this in GitHub Secret vault. This will be public anyway.
 
-In every docker container there are two files:
+### `COSIGN_PRIVATE_KEY`
 
-* `TAGS` - contains all tags associated with this container at time it was build.
-* `REPO` - contains a link to the github repository with the commit sha.
+**Optional** Cosign Private Key used to attach provenance file.
+Please make sure this is a GitHub Secret.
+
+###  `COSIGN_PASSWORD`
+
+**Optional** Cosign Password used to attach provenance file.
+Please make sure this is a GitHub Secret.
+
+###  `COSIGN_PUBLIC_KEY`
+
+**Optional** Cosign Public Key used to attach provenance file.
+No need to put this in GitHub Secret vault. Good practice is to put this also in a repo as `cosign.pub`.
+
 
 <!-- action-docs-outputs -->
 ## Outputs
@@ -105,8 +119,8 @@ This action is an `docker` action.
 
 ## Example usage
 
-``` 
-- uses: philips-software/docker-ci-scripts@v3.0.0
+```yaml
+- uses: philips-software/docker-ci-scripts@v3.4.0
   with:
     dockerfile: './docker/Dockerfile'
     image-name: 'node'
@@ -119,37 +133,58 @@ This action is an `docker` action.
 
 #### With GitHub Package registry:
 
-```
-      - name: Build Docker Images
-        uses: philips-software/docker-ci-scripts@v3.3.2
-        with:
-          dockerfile: .
-          image-name: image-name-here
-          tags: latest 0.1
-          push-branches: main develop
-        env:
-          DOCKER_USERNAME: ${{ github.actor }}
-          DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          DOCKER_REGISTRY: ghcr.io/organization-here
-          GITHUB_ORGANIZATION: organization-here
+```yaml
+- name: Build Docker Images
+  uses: philips-software/docker-ci-scripts@v3.4.0
+  with:
+    dockerfile: .
+    image-name: image-name-here
+    tags: latest 0.1
+    push-branches: main develop
+  env:
+    DOCKER_USERNAME: ${{ github.actor }}
+    DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+    DOCKER_REGISTRY: ghcr.io/organization-here
+    GITHUB_ORGANIZATION: organization-here
 ```
 
 #### With SLSA Provenance:
 
+```yaml
+- name: Build Docker Images
+  uses: philips-software/docker-ci-scripts@v3.4.0
+  with:
+    dockerfile: .
+    image-name: image-name-here
+    tags: latest 0.1
+    push-branches: main develop
+    slsa-provenance: true
+  env:
+    DOCKER_USERNAME: ${{ github.actor }}
+    DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+    DOCKER_REGISTRY: ghcr.io/organization-here
+    GITHUB_ORGANIZATION: organization-here
 ```
-      - name: Build Docker Images
-        uses: philips-software/docker-ci-scripts@v3.3.2
-        with:
-          dockerfile: .
-          image-name: image-name-here
-          tags: latest 0.1
-          push-branches: main develop
-          slsa-provenance: true
-        env:
-          DOCKER_USERNAME: ${{ github.actor }}
-          DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          DOCKER_REGISTRY: ghcr.io/organization-here
-          GITHUB_ORGANIZATION: organization-here
+
+#### With SLSA Provenance attached to Image:
+
+```yaml
+- name: Build Docker Images
+  uses: philips-software/docker-ci-scripts@v3.3.2
+  with:
+    dockerfile: .
+    image-name: image-name-here
+    tags: latest 0.1
+    push-branches: main develop
+    slsa-provenance: true
+  env:
+    DOCKER_USERNAME: ${{ github.actor }}
+    DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+    DOCKER_REGISTRY: ghcr.io/organization-here
+    GITHUB_ORGANIZATION: organization-here
+    COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+    COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+    COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
 ```
 
 ## Example projects
@@ -180,4 +215,3 @@ Example:
 ## License
 
 [MIT License](./LICENSE)
-

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This action will build a docker container from a given directory.
 - Each docker container contains information about the exact context in which the container is build.
 - When pushing to docker.io, the description is updated with the `readme.md` file.
 - If required, a provenance file is created according to the [SLSA.dev](https://slsa.dev) specifications. 
+- If required, the provenance file is attached to the container. 
 
 In every docker container there are two files:
 * `TAGS` - contains all tags associated with this container at time it was build.
@@ -185,6 +186,13 @@ This action is an `docker` action.
     COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
     COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
     COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
+```
+
+Verify attestation for a certain docker-repo f.e. `jeroenknoops/test-image:latest`:
+
+```bash
+repodigest=$(docker inspect jeroenknoops/test-image:latest | jq -r .[0].RepoDigests[0])
+cosign verify-attestation --key cosign.pub $repodigest | jq -r '.payload' | base64 -d
 ```
 
 ## Example projects

--- a/README.md
+++ b/README.md
@@ -188,12 +188,15 @@ This action is an `docker` action.
     COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
 ```
 
-Verify attestation for a certain docker-repo f.e. `jeroenknoops/test-image:latest`:
+Now you can verify the attestation for a certain docker-repo f.e. `jeroenknoops/test-image:latest`:
 
 ```bash
 repodigest=$(docker inspect jeroenknoops/test-image:latest | jq -r .[0].RepoDigests[0])
 cosign verify-attestation --key cosign.pub $repodigest | jq -r '.payload' | base64 -d
 ```
+
+This is nice, because you can see how and when the image was build, without downloading it!
+You can inspect the provenance and decide on whether you want use the image.
 
 ## Example projects
 

--- a/bin/install_cosign.sh
+++ b/bin/install_cosign.sh
@@ -7,6 +7,8 @@ RUNNER_OS=$(uname)
 # RUNNER_ARCH=$(uname -m)
 RUNNER_ARCH=X64
 
+uname -a
+
 #cosign install script
 shopt -s expand_aliases
 if [ -z "$NO_COLOR" ]; then

--- a/bin/install_slsa_provenance.sh
+++ b/bin/install_slsa_provenance.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SLSA_PROVENANCE_VERSION=0.5.1
+SLSA_PROVENANCE_VERSION=0.6.0
 INSTALL_DIR=$HOME/.slsa_provenance
 
 function install_slsa_provenance {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,10 +11,7 @@ then
   echo "- SLSA Provenance ---------"
 fi
 
-# For future extention.
-# 1) Attach SLSA_PROVENANCE json to docker image
-# 2) Sign docker image
-if [ -n "${COSIGN}" ]
+if [ -n "${COSIGN_PRIVATE_KEY}" ]
 then
   echo "+ Cosign ------------------"
   echo "| Installing cosign"


### PR DESCRIPTION
# Purpose

Attach provenance file created in #94 to container by using cosign.

Now you can attach the provenance file to an image by adding the COSIGN environment variables.

## Example step in workflow
```yaml
    - uses: philips-software/docker-ci-scripts@3.4.0
      with:
        dockerfile: 1
        image-name: test-image 
        tags: 'latest 1 1.2 1.2.1'
        slsa-provenance: true
      env:
        DOCKER_USERNAME: <docker-username>
        DOCKER_PASSWORD: '${{ secrets.DOCKER_PASSWORD }}'
        DOCKER_ORGANIZATION: <docker-organization>
        COSIGN_PRIVATE_KEY: '${{ secrets.COSIGN_PRIVATE_KEY }}'
        COSIGN_PASSWORD: '${{ secrets.COSIGN_PASSWORD }}'
        COSIGN_PUBLIC_KEY: '${{ secrets.COSIGN_PUBLIC_KEY  }}'
```

Public Cosign key is necessary to verify the attestation afterwards.

# Link to test repository

- workflow: https://github.com/JeroenKnoops/test-docker-ci-scripts/blob/main/.github/workflows/build_docker.yml
- run: https://github.com/JeroenKnoops/test-docker-ci-scripts/actions/runs/1746557090

## Verify Attestation

This is an example on how to verify the attestation created in test repository. ( cosign.pub can be found in the repository ) 
```bash
cosign verify-attestation --key cosign.pub jeroenknoops/test-image@sha256:0f8f87ca4e496d478d7045a33b9d466dac43f2c96be48072cc11d13f12040add | jq -r '.payload' | base64 -d
```

# Related PR
Please first merge the PR regarding SLSA-provenance: #94 

# Related Issue
Issue #78
