### PR TITLE
Sign docker image with cosign

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
   slsa-provenance:
     description: 'Create SLSA Provenance json'
     required: false
+  sign:
+    description: 'Sign image with Cosign. Requires COSIGN environment variables to be set. When used in combination with slsa-provenance it will also attach the slsa-provenance to the image.'
+    required: false
   github_context:
     description: 'internal (do not set): the "github" context object in json'
     required: true
@@ -35,9 +38,9 @@ inputs:
     default: ${{ toJSON(runner) }}
 outputs:
   container-digest:
-    description: 'Container digest. Can be used for generating provenance and signing.'
+    description: 'Container digest. Can be used for generating provenance and signing'
   container-tags:
-    description: 'Container tags. Can be used for generating provenance and signing.'
+    description: 'Container tags. Can be used for generating provenance and signing'
   push-indicator:
     description: 'Is set to true when containers have been pushed to the container repository'
   slsa-provenance-file:
@@ -54,5 +57,6 @@ runs:
     - ${{ inputs.push-branch }}
   env:
     SLSA_PROVENANCE: ${{ inputs.slsa-provenance }}
+    SIGN: ${{ inputs.sign }}
     GITHUB_CONTEXT: ${{ inputs.github_context }}
     RUNNER_CONTEXT: ${{ inputs.runner_context }}

--- a/container_digest.sh
+++ b/container_digest.sh
@@ -105,6 +105,12 @@ then
   echo "${COSIGN_PUBLIC_KEY}" > cosign.pub
   cosign verify-attestation --key cosign.pub "$docker_registry_prefix"/"$imagename"@"${containerdigest}"
 
+  echo "Sign image"
+  cosign sign --key cosign.key "$docker_registry_prefix"/"$imagename"@"${containerdigest}"
+
+  echo "Verify signing"
+  cosign verify --key cosign.pub "$docker_registry_prefix"/"$imagename"@"${containerdigest}" 
+
   echo "Cleanup"
   rm cosign.key
   rm cosign.pub

--- a/container_digest.sh
+++ b/container_digest.sh
@@ -62,6 +62,24 @@ echo "==========================================================================
 echo "Finished getting docker digest and tags"
 echo "============================================================================================"
 
+if [ -n "${SIGN}" ]
+then
+  echo "Signing image"
+
+  # COSGIN_PASSWORD should be passed as environment variable
+  echo "${COSIGN_PRIVATE_KEY}" > cosign.key
+
+  echo "Sign image"
+  cosign sign --key cosign.key "$docker_registry_prefix"/"$imagename"@"${containerdigest}"
+
+  echo "Verify signing"
+  cosign verify --key cosign.pub "$docker_registry_prefix"/"$imagename"@"${containerdigest}" 
+
+  echo "Cleanup"
+  rm cosign.key
+  rm cosign.pub
+fi
+
 if [ -n "${SLSA_PROVENANCE}" ]
 then
   echo "Running SLSA Provenance"
@@ -88,31 +106,26 @@ then
   echo "============================================================================================"
   echo "Finished getting SLSA Provenance"
   echo "============================================================================================"
-fi
 
-if [ -n "${COSIGN_PRIVATE_KEY}" ]
-then
-  echo "Attaching SLSA Provenance with Cosign"
-  echo "Get predicate"
-  jq .predicate < provenance.json > provenance-predicate.json
+  if [ -n "${SIGN}" ]
+  then
+    echo "Attaching SLSA Provenance with Cosign"
+    echo "Get predicate"
+    echo "${COSIGN_PRIVATE_KEY}" > cosign.key
+    jq .predicate < provenance.json > provenance-predicate.json
 
-  echo "Attest predicate"
-  # COSGIN_PASSWORD should be passed as environment variable
-  echo "${COSIGN_PRIVATE_KEY}" > cosign.key
-  cosign attest --predicate provenance-predicate.json --key cosign.key --type slsaprovenance "$docker_registry_prefix"/"$imagename"@"${containerdigest}"
+    echo "Attest predicate"
+    # COSGIN_PASSWORD should be passed as environment variable
+    echo "${COSIGN_PRIVATE_KEY}" > cosign.key
+    cosign attest --predicate provenance-predicate.json --key cosign.key --type slsaprovenance "$docker_registry_prefix"/"$imagename"@"${containerdigest}"
 
-  echo "Verify predicate"
-  echo "${COSIGN_PUBLIC_KEY}" > cosign.pub
-  cosign verify-attestation --key cosign.pub "$docker_registry_prefix"/"$imagename"@"${containerdigest}"
+    echo "Verify predicate"
+    echo "${COSIGN_PUBLIC_KEY}" > cosign.pub
+    cosign verify-attestation --key cosign.pub "$docker_registry_prefix"/"$imagename"@"${containerdigest}"
 
-  echo "Sign image"
-  cosign sign --key cosign.key "$docker_registry_prefix"/"$imagename"@"${containerdigest}"
-
-  echo "Verify signing"
-  cosign verify --key cosign.pub "$docker_registry_prefix"/"$imagename"@"${containerdigest}" 
-
-  echo "Cleanup"
-  rm cosign.key
-  rm cosign.pub
+    echo "Cleanup"
+    rm cosign.key
+    rm cosign.pub
+  fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ then
   echo "- SLSA Provenance ---------"
 fi
 
-if [ -n "${COSIGN_PRIVATE_KEY}" ]
+if [ -n "${SIGN}" ]
 then
   echo "+ Cosign ------------------"
   echo "| Installing cosign"


### PR DESCRIPTION
# Change
When added an argument (`sign: true`) it will sign the image with [Cosign](https://github.com/sigstore/cosign).

## Cosign key-pair
You need to provide the COSIGN environment variables in order to actually sign it.
You can create a key pair by installing Cosign on your local machine and run:
```bash
cosign generate-key-pair
```

Store the content of `cosign.pub`, `cosign.key` and the password in GitHub Secrets.

## Workflow
Now you can use it in a workflow:
```yaml
- name: Build Docker Images
  uses: philips-software/docker-ci-scripts@v4.0.0
  with:
    dockerfile: .
    image-name: image-name-here
    tags: latest 0.1
    push-branches: main develop
    sign: true
  env:
    DOCKER_USERNAME: ${{ github.actor }}
    DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
    DOCKER_REGISTRY: ghcr.io/organization-here
    GITHUB_ORGANIZATION: organization-here
    COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
    COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
    COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
```

## Verify image
Now you can verify the image:

```bash
  cosign verify --key cosign.pub organization-here/image-name-here:latest
```

You will get a result when the image is valid and an error if not.

## Breaking change
Previously a SLSA Provenance file was attached when the environment variable `COSIGN_PRIVATE_KEY` was set. This has been changed, now it only attaches the file to the image when the argument `SIGN: true` is set.

# Related issue
Closes #78 