### PR TITLE
Update version of slsa to 0.7.0 and cosign to 1.5.1

### DIFF
--- a/bin/install_cosign.sh
+++ b/bin/install_cosign.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-COSIGN_RELEASE=v1.4.1
+COSIGN_RELEASE=v1.5.1
 INSTALL_DIR=$HOME/.cosign
 
 RUNNER_OS=$(uname)

--- a/bin/install_slsa_provenance.sh
+++ b/bin/install_slsa_provenance.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SLSA_PROVENANCE_VERSION=0.6.0
+SLSA_PROVENANCE_VERSION=0.7.0
 INSTALL_DIR=$HOME/.slsa_provenance
 
 function install_slsa_provenance {


### PR DESCRIPTION
Update versions of SLSA provenance and Cosign

# Tools

## SLSA-provenance-action 0.7.0

Release notes: https://github.com/philips-labs/slsa-provenance-action/releases/tag/v0.7.0

## Cosign 1.5.1
Release notes: https://github.com/sigstore/cosign/releases/tag/v1.5.1
