### PR TITLE
Use Syft for SBOM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,7 @@ RUN chmod +x /scripts/install_cosign.sh
 ADD bin/install_slsa_provenance.sh /scripts
 RUN chmod +x /scripts/install_slsa_provenance.sh
 
+ADD bin/install_syft.sh /scripts
+RUN chmod +x /scripts/install_syft.sh
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/bin/install_syft.sh
+++ b/bin/install_syft.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+SYFT_VERSION=0.37.10
+INSTALL_DIR=$HOME/.syft
+
+function install_syft {
+    case "$(uname -s)" in
+        Linux*)
+            machine=linux
+            shasum=sha256sum
+            ;;
+        Darwin*)
+            machine=macOS
+            shasum=shasum
+            ;;
+    esac
+
+    curl -sSLO https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_${machine}_amd64.tar.gz
+    curl -sSLO https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_checksums.txt
+    < syft_${SYFT_VERSION}_checksums.txt grep syft_${SYFT_VERSION}_${machine}_amd64.tar.gz | $shasum -c -
+
+    # shellcheck disable=SC2181
+    if [ $? != 0 ] ; then
+        echo Checksum does not match.
+        exit 1
+    fi
+
+    mkdir -p "${INSTALL_DIR}"
+    tar -xf syft_${SYFT_VERSION}_${machine}_amd64.tar.gz -C "${INSTALL_DIR}"
+    chmod +x "${INSTALL_DIR}"/syft
+    rm -f syft_${SYFT_VERSION}_${machine}_amd64.tar.gz syft_${SYFT_VERSION}_checksums.txt
+}
+
+install_syft
+export PATH=${INSTALL_DIR}:$PATH

--- a/container_digest.sh
+++ b/container_digest.sh
@@ -125,9 +125,9 @@ fi
 
 if [ -n "${SBOM}" ]
 then
-  echo "Using TERN to generate SBOM"
+  echo "Using Syft to generate SBOM"
 
-  docker run --rm philipssoftware/tern:2.9.1 report -f json -i "$docker_registry_prefix"/"$imagename"@"${containerdigest}" > sbom-spdx.json
+  syft packages "$docker_registry_prefix"/"$imagename"@"${containerdigest}" -o spdx-json=sbom-spdx.json
 
   echo "::set-output name=sbom-file::sbom-spdx.json"
 

--- a/container_digest.sh
+++ b/container_digest.sh
@@ -117,8 +117,8 @@ then
     echo "Attest predicate"
     cosign attest --predicate provenance-predicate.json --key "$COSIGN_KEY" --type slsaprovenance "$docker_registry_prefix"/"$imagename"@"${containerdigest}"
 
-    echo "Verify predicate"
-    cosign verify-attestation --key "$COSIGN_PUB" "$docker_registry_prefix"/"$imagename"@"${containerdigest}"
+    # echo "Verify predicate"
+    # cosign verify-attestation --key "$COSIGN_PUB" "$docker_registry_prefix"/"$imagename"@"${containerdigest}"
 
   fi
 fi
@@ -142,8 +142,10 @@ then
     echo "Attest SBOM"
     cosign attest --predicate sbom-spdx.json --type spdx --key "$COSIGN_KEY" "$docker_registry_prefix"/"$imagename"@"${containerdigest}"
 
-    echo "Verify SBOM"
-    cosign verify-attestation --key "$COSIGN_PUB" "$docker_registry_prefix"/"$imagename"@"${containerdigest}"
+    echo "Done attesting the SBOM"
+
+    echo "You can verify the attestation with:"
+    echo "  $ cosign verify-attestation --key $COSIGN_PUB ${docker_registry_prefix}/${imagename}@${containerdigest}"
   fi
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,6 +23,17 @@ then
   echo "- Cosign ------------------"
 fi
 
+if [ -n "${SBOM}" ]
+then
+  echo "+ SBOM -------------------"
+  echo "| Installing Syft"
+  . $GITHUB_ACTION_PATH/scripts/install_syft.sh
+  echo "| Show Syft version"
+  syft version
+  echo "| Finished installing Syft"
+  echo "- Syft -------------------"
+fi
+
 echo "dockerfile     : $1"
 echo "image name     : $2"
 echo "tags           : $3"


### PR DESCRIPTION
# Reason
Syft will be used to generate an SBOM. This is not running in a docker container, so it uses the same docker login as the rest, so this will work for private repositories as well.

## How to check

We've created an SBOM for the following repo: https://github.com/philips-software/docker-blackduck. In this repo you can find the public key of cosign which is used to verify the attestation.

```bash
cosign verify-attestation --key cosign.pub philipssoftware/blackduck@sha256:86dcd3227a97e34620c21f4199bc9ea7ca2aab32db3cc8bea0bd4ef034e66025 --output-file attestations.json
```

# Related issues
Closes #102, #104

# Next things....
[Check CUE and Rego](https://docs.sigstore.dev/cosign/attestation)