### PR TITLE
Add push on tags

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
   push-branches:
     description: 'Specifies branches to push, separated by a space'
     default: 'master main'
+  push-on-git-tag:
+    description: 'Push when a git tag is created'
+    default: 'false'
   base-dir:
     description: 'Base directory to perform the build'
     default: '.'
@@ -65,5 +68,6 @@ runs:
     SLSA_PROVENANCE: ${{ inputs.slsa-provenance }}
     SBOM: ${{ inputs.sbom }}
     SIGN: ${{ inputs.sign }}
+    PUSH_ON_GIT_TAG: ${{ inputs.push-on-git-tag }}
     GITHUB_CONTEXT: ${{ inputs.github_context }}
     RUNNER_CONTEXT: ${{ inputs.runner_context }}

--- a/docker_build_and_push.sh
+++ b/docker_build_and_push.sh
@@ -24,9 +24,14 @@ push() {
 echo "Check if PUSH_ON_GIT_TAG is set"
 if [ "$PUSH_ON_GIT_TAG" = true ]
 then
-  echo "PUSH_ON_GIT_TAG is set: start pushing"
-  push "$@"
-  exit 0
+  if [[ $GITHUB_REF == refs/tags/* ]]
+  then
+    echo "PUSH_ON_GIT_TAG is set and GITHUB_REF ( $GITHUB_REF ) is a tag: start pushing"
+    push "$@"
+    exit 0
+  else
+    echo "GITHUB_REF is not a tag.. it is: ${GITHUB_REF}"
+  fi
 else
   echo "PUSH_ON_GIT_TAG is not set"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,6 +34,13 @@ then
   echo "- Syft -------------------"
 fi
 
+if [ "${PUSH_ON_GIT_TAG}" = true ]
+then
+  echo "+ PUSH_ON_GIT_TAG -------------------"
+  echo "| Push on git tag flag is set to true."
+  echo "- PUSH_ON_GIT_TAG -------------------"
+fi
+
 echo "dockerfile     : $1"
 echo "image name     : $2"
 echo "tags           : $3"


### PR DESCRIPTION
Add `push-on-git-tag` boolean argument.

This means when `push-on-git-tag` is set to true, the action will also push the images when a tag is created.

Closes #130