### PR TITLE
Rename variables related to registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project uses the version of main tool as main version number .
 
 - [#50] - Fix: Automatic push of README to docker hub is broken.
 - [#48] - Loop through entire array of push-branches
+- [#34] - ** BREAKING ** Rename variables DOCKER_USERNAME, DOCKER_PASSWORD and DOCKER_REGISTRY
 
 ## v3.1.0 - 2020-09-23
 - Allow users to specify multiple branches to push to the artifact repository. `push-branches`

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Philips Software
+Copyright (c) 2020 - 2022 Philips Software
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -71,15 +71,15 @@ Builds docker images and publish them on request
 
 These variables can be set in the github repository secret vault.
 
-### `DOCKER_USERNAME`
+### `REGISTRY_USERNAME`
 
-**Required** Docker username
+**Required** Registry username
 
-### `DOCKER_PASSWORD`
+### `REGISTRY_TOKEN`
 
-**Required** Docker password
+**Required** Registry token
 
-### `DOCKER_REGISTRY`
+### `REGISTRY_URL`
 
 **Optional** Registry to push the docker image to. Defaults to Docker hub.
 
@@ -158,8 +158,8 @@ This action is a `docker` action.
     image-name: "node"
     tags: "latest 12 12.1 12.1.4"
   env:
-    DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-    DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
+    REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+    REGISTRY_TOKEN: "${{ secrets.REGISTRY_TOKEN }}"
     DOCKER_ORGANIZATION: myDockerOrganization
 ```
 
@@ -172,8 +172,8 @@ This action is a `docker` action.
     image-name: "node"
     tags: "latest 12 12.1 12.1.4"
   env:
-    DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-    DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
+    REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+    REGISTRY_TOKEN: "${{ secrets.REGISTRY_TOKEN }}"
     DOCKER_ORGANIZATION: myDockerOrganization
     FOO_BUILD_ARG: "foo"
     BAR_BUILD_ARG: ${{ secrets.SECRET_BAR_BUILD_ARG }}
@@ -191,9 +191,9 @@ This action is a `docker` action.
     tags: latest 0.1
     push-branches: main develop
   env:
-    DOCKER_USERNAME: ${{ github.actor }}
-    DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-    DOCKER_REGISTRY: ghcr.io/organization-here
+    REGISTRY_USERNAME: ${{ github.actor }}
+    REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    REGISTRY_URL: ghcr.io/organization-here
     GITHUB_ORGANIZATION: organization-here
 ```
 
@@ -220,9 +220,9 @@ Store the content of `cosign.pub`, `cosign.key` and the password in GitHub Secre
     push-branches: main develop
     sign: true
   env:
-    DOCKER_USERNAME: ${{ github.actor }}
-    DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-    DOCKER_REGISTRY: ghcr.io/organization-here
+    REGISTRY_USERNAME: ${{ github.actor }}
+    REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    REGISTRY_URL: ghcr.io/organization-here
     GITHUB_ORGANIZATION: organization-here
     COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
     COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
@@ -250,9 +250,9 @@ You will get a result when the image is valid.
     push-branches: main develop
     slsa-provenance: true
   env:
-    DOCKER_USERNAME: ${{ github.actor }}
-    DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-    DOCKER_REGISTRY: ghcr.io/organization-here
+    REGISTRY_USERNAME: ${{ github.actor }}
+    REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    REGISTRY_URL: ghcr.io/organization-here
     GITHUB_ORGANIZATION: organization-here
 - name: Show provenance
   run: |
@@ -275,9 +275,9 @@ the COSIGN environment variables. (see #sign how to generate the key-pair)
     slsa-provenance: true
     sign: true
   env:
-    DOCKER_USERNAME: ${{ github.actor }}
-    DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-    DOCKER_REGISTRY: ghcr.io/organization-here
+    REGISTRY_USERNAME: ${{ github.actor }}
+    REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    REGISTRY_URL: ghcr.io/organization-here
     GITHUB_ORGANIZATION: organization-here
     COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
     COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
@@ -306,9 +306,9 @@ You can inspect the provenance and decide on whether you want use the image.
     push-branches: main develop
     sbom: true
   env:
-    DOCKER_USERNAME: ${{ github.actor }}
-    DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-    DOCKER_REGISTRY: ghcr.io/organization-here
+    REGISTRY_USERNAME: ${{ github.actor }}
+    REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    REGISTRY_URL: ghcr.io/organization-here
     GITHUB_ORGANIZATION: organization-here
 - name: Show SBOM
   run: |
@@ -331,9 +331,9 @@ the COSIGN environment variables. (see #sign how to generate the key-pair)
     sbom: true
     sign: true
   env:
-    DOCKER_USERNAME: ${{ github.actor }}
-    DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-    DOCKER_REGISTRY: ghcr.io/organization-here
+    REGISTRY_USERNAME: ${{ github.actor }}
+    REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    REGISTRY_URL: ghcr.io/organization-here
     GITHUB_ORGANIZATION: organization-here
     COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
     COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
@@ -363,9 +363,9 @@ the COSIGN environment variables. (see #sign how to generate the key-pair)
     sign: true
     slsa-provenance: true
   env:
-    DOCKER_USERNAME: ${{ github.actor }}
-    DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-    DOCKER_REGISTRY: ghcr.io/organization-here
+    REGISTRY_USERNAME: ${{ github.actor }}
+    REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    REGISTRY_URL: ghcr.io/organization-here
     GITHUB_ORGANIZATION: organization-here
     COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
     COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
@@ -413,8 +413,8 @@ This can be done with a small snippet:
     tags: "latest ${{ env.major }} ${{ env.minor }} ${{ env.patch }}"
     push-on-git-tag: "true"
   env:
-    DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-    DOCKER_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}"
+    REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+    REGISTRY_TOKEN: "${{ secrets.REGISTRY_TOKEN }}"
     DOCKER_ORGANIZATION: myDockerOrganization
 ```
 

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -22,18 +22,18 @@ echo "--------------------------------------------------------------------------
 # shellcheck disable=SC2153
 docker_organization=$DOCKER_ORGANIZATION
 
-if [ -z "$DOCKER_REGISTRY" ]; then
+if [ -z "$REGISTRY_URL" ]; then
   if [ -z "$docker_organization" ]; then
     echo "  No DOCKER_ORGANIZATION set. This is mandatory when using docker.io"
     exit 1
   fi
-  docker_registry_prefix="docker.io/$docker_organization"
+  registry_url_prefix="docker.io/$docker_organization"
   echo "Docker organization: $docker_organization"
 else
-  docker_registry_prefix="$DOCKER_REGISTRY"
+  registry_url_prefix="$REGISTRY_URL"
 fi
 
-echo "docker_registry_prefix: $docker_registry_prefix"
+echo "registry_url_prefix: $registry_url_prefix"
 
 # Checking GITHUB_ORGANIZATION environment variable
 
@@ -92,12 +92,12 @@ echo "repo: https://github.com/$project/tree/$commitsha"
 echo "https://github.com/$project/tree/$commitsha" >REPO
 
 # shellcheck disable=SC2086
-docker build . -f "$dockerfilepath" -t "$docker_registry_prefix"/"$imagename":"$basetag" $docker_build_args
+docker build . -f "$dockerfilepath" -t "$registry_url_prefix"/"$imagename":"$basetag" $docker_build_args
 
 echo "--------------------------------------------------------------------------------------------"
 for tag in "${tags[@]:1}"; do
-  echo "Tagging $docker_registry_prefix/$imagename:$basetag as $docker_registry_prefix/$imagename:$tag"
-  docker tag "$docker_registry_prefix"/"$imagename":"$basetag" "$docker_registry_prefix"/"$imagename":"$tag"
+  echo "Tagging $registry_url_prefix/$imagename:$basetag as $registry_url_prefix/$imagename:$tag"
+  docker tag "$registry_url_prefix"/"$imagename":"$basetag" "$registry_url_prefix"/"$imagename":"$tag"
 done
 echo "============================================================================================"
 echo "Finished building docker images from: $dockerfilepath"

--- a/update_readme.sh
+++ b/update_readme.sh
@@ -10,7 +10,7 @@ README_FILEPATH="/github/workspace/${README_FILEPATH:="README.md"}"
 
 # Acquire a token for the Docker Hub API
 echo "Acquiring token"
-LOGIN_PAYLOAD="{\"username\": \"${DOCKER_USERNAME}\", \"password\": \"${DOCKER_PASSWORD}\"}"
+LOGIN_PAYLOAD="{\"username\": \"${REGISTRY_USERNAME}\", \"password\": \"${REGISTRY_TOKEN}\"}"
 TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d "${LOGIN_PAYLOAD}" https://hub.docker.com/v2/users/login/ | jq -r .token)
 
 # Send a PATCH request to update the description of the repository


### PR DESCRIPTION
Per suggestion of #34 , renamed variables related to docker image registry.

Renamed variables: 

- DOCKER_USERNAME => REGISTRY_USERNAME
- DOCKER_PASSWORD => REGISTRY_TOKEN
- DOCKER_REGISTRY => REGISTRY_URL

Also derived internal variable names are renamed according to the renaming above.

Also update LICENSE.md to extend copyright to include current year