### PR TITLE
fix: GITHUB_OUTPUT doesn't need {}

### DIFF
--- a/container_digest.sh
+++ b/container_digest.sh
@@ -49,14 +49,14 @@ docker pull "$registry_url_prefix"/"$imagename":"$basetag"
 echo "Getting digest for $registry_url_prefix/$imagename:$basetag"
 containerdigest=$(docker inspect "$registry_url_prefix"/"$imagename":"$basetag" --format '{{ index .RepoDigests 0 }}' | cut -d '@' -f 2)
 echo "found: ${containerdigest}"
-echo "{container-digest}={${containerdigest}}" >> "$GITHUB_OUTPUT"
+echo "container-digest=${containerdigest}" >> "$GITHUB_OUTPUT"
 
 echo "--------------------------------------------------------------------------------------------"
 
 echo "Getting tags"
 containertags=$(docker inspect "$registry_url_prefix"/"$imagename":"$basetag" --format '{{ join .RepoTags "\n" }}' | sed 's/.*://' | paste -s -d ',' -)
 echo "found: ${containertags}"
-echo "{container-tags}={${containertags}}" >> "$GITHUB_OUTPUT"
+echo "container-tags=${containertags}" >> "$GITHUB_OUTPUT"
 
 echo "============================================================================================"
 echo "Finished getting docker digest and tags"
@@ -107,7 +107,7 @@ then
   echo "-------------------------------------------------------------------------------------------"
   echo " provenance.json "
   echo "-------------------------------------------------------------------------------------------"
-  echo "{slsa-provenance-file}={provenance.json}" >> "$GITHUB_OUTPUT"
+  echo "slsa-provenance-file=provenance.json" >> "$GITHUB_OUTPUT"
 
   echo "============================================================================================"
   echo "Finished getting SLSA Provenance"
@@ -142,7 +142,7 @@ then
   echo "Remove formatting"
   jq -c . sbom-spdx-formatted.json > sbom-spdx.json
 
-  echo "{sbom-file}={sbom-spdx.json}" >> "$GITHUB_OUTPUT"
+  echo "sbom-file=sbom-spdx.json" >> "$GITHUB_OUTPUT"
 
   echo "============================================================================================"
   echo "Finished getting SBOM"

--- a/docker_build_and_push.sh
+++ b/docker_build_and_push.sh
@@ -13,7 +13,7 @@ if [ "$#" -lt 4 ]; then
 fi
 
 push() {
-  echo "{push-indicator}={true}" >> "$GITHUB_OUTPUT"
+  echo "push-indicator=true" >> "$GITHUB_OUTPUT"
 
   "${FOREST_DIR}"/docker_push.sh "$@"
   "${FOREST_DIR}"/container_digest.sh "$@"
@@ -53,4 +53,3 @@ done
 
 echo "No branches matched to current branch. No need to push the images to docker hub."
 exit 0
-


### PR DESCRIPTION
Using the output variables in a job is broken after the changes to GITHUB_OUTPUT as can be seen in https://github.com/philips-internal/amp-connectivity-devcontainer/pull/20.

The GitHub documentation is a bit misleading in this respect. See: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter.

The shell snippet looks like this:
```shell
echo "{name}={value}" >> $GITHUB_OUTPUT
```

While the example looks like this:
```yaml
      - name: Set color
        id: random-color-generator
        run: echo "SELECTED_COLOR=green" >> $GITHUB_OUTPUT
      - name: Get color
        run: echo "The selected color is ${{ steps.random-color-generator.outputs.SELECTED_COLOR }}"
```

I have removed all parenthesis in this PR.