### PR TITLE
Check vulnerabilities

### DIFF
--- a/.github/workflows/check-vulnerabilities.yaml
+++ b/.github/workflows/check-vulnerabilities.yaml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       runs_on:
-        default: "[ubuntu-latest]"
+        default: ubuntu-latest
         description: Runner specification
         required: false
         type: string

--- a/.github/workflows/check-vulnerabilities.yaml
+++ b/.github/workflows/check-vulnerabilities.yaml
@@ -29,7 +29,8 @@ jobs:
       - name: Get SBOM
         id: spdx
         run: |
-          echo "spdx=$(COSIGN_EXPERIMENTAL=1 cosign verify-attestation --type spdx ${{ inputs.image }} | jq '.payload |= @base64d | .payload | fromjson | select( .predicateType=='https://spdx.dev/Document' ) | .predicate.Data | fromjson | .") >> $GITHUB_OUTPUT
+          SPDX=$(COSIGN_EXPERIMENTAL=1 cosign verify-attestation --type spdx ${{ inputs.image }} | jq '.payload |= @base64d | .payload | fromjson | select( .predicateType=="https://spdx.dev/Document" ) | .predicate.Data | fromjson | .')
+          echo "spdx=$SPDX" >> $GITHUB_OUTPUT
       - name: Scan image
         uses: anchore/scan-action@v3
         with:

--- a/.github/workflows/check-vulnerabilities.yaml
+++ b/.github/workflows/check-vulnerabilities.yaml
@@ -29,11 +29,13 @@ jobs:
       - name: Get SBOM
         id: spdx
         run: |
-          SPDX=$(COSIGN_EXPERIMENTAL=1 cosign verify-attestation --type spdx ${{ inputs.image }} | jq '.payload |= @base64d | .payload | fromjson | select( .predicateType=="https://spdx.dev/Document" ) | .predicate.Data | fromjson | .')
-          echo "spdx=$SPDX" >> $GITHUB_OUTPUT
+          COSIGN_EXPERIMENTAL=1 cosign verify-attestation --type spdx ${{ inputs.image }} | jq '.payload |= @base64d | .payload | fromjson | select( .predicateType=="https://spdx.dev/Document" ) | .predicate.Data | fromjson | .' > spdx.json
       - name: Scan image
         uses: anchore/scan-action@v3
         with:
-          sbom: ${{ steps.spdx.outputs.spdx }}
+          sbom: spdx.json
           fail-build: true
           severity-cutoff: critical
+      - name: Remove json 
+        run: |
+          rm spdx.json 

--- a/.github/workflows/check-vulnerabilities.yaml
+++ b/.github/workflows/check-vulnerabilities.yaml
@@ -27,15 +27,15 @@ jobs:
         run: |
           COSIGN_EXPERIMENTAL=1 cosign verify ${{ inputs.image }}
       - name: Get SBOM
-        id: spdx
         run: |
           COSIGN_EXPERIMENTAL=1 cosign verify-attestation --type spdx ${{ inputs.image }} | jq '.payload |= @base64d | .payload | fromjson | select( .predicateType=="https://spdx.dev/Document" ) | .predicate.Data | fromjson | .' > spdx.json
       - name: Scan image
+        id: scan
         uses: anchore/scan-action@v3
         with:
           sbom: spdx.json
-          fail-build: true
-          severity-cutoff: critical
+      - name: Inspect action SARIF report
+        run: cat ${{ steps.scan.outputs.sarif }}
       - name: Remove json 
         run: |
           rm spdx.json 

--- a/.github/workflows/check-vulnerabilities.yaml
+++ b/.github/workflows/check-vulnerabilities.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: anchore/scan-action@v3
         with:
           sbom: spdx.json
-          output: table
+          output-format: table
           fail-build: false
       - name: Remove json 
         run: |

--- a/.github/workflows/check-vulnerabilities.yaml
+++ b/.github/workflows/check-vulnerabilities.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Get SBOM
         id: spdx
         run: |
-          echo "spdx=$(COSIGN_EXPERIMENTAL=1 cosign verify-attestation --type spdx ${{ inputs.image }} | jq '.payload |= @base64d | .payload | fromjson | select( .predicateType=="https://spdx.dev/Document" ) | .predicate.Data | fromjson | .') >> $GITHUB_OUTPUT
+          echo "spdx=$(COSIGN_EXPERIMENTAL=1 cosign verify-attestation --type spdx ${{ inputs.image }} | jq '.payload |= @base64d | .payload | fromjson | select( .predicateType=='https://spdx.dev/Document' ) | .predicate.Data | fromjson | .') >> $GITHUB_OUTPUT
       - name: Scan image
         uses: anchore/scan-action@v3
         with:

--- a/.github/workflows/check-vulnerabilities.yaml
+++ b/.github/workflows/check-vulnerabilities.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Get SBOM
         id: spdx
         run: |
-          echo "spdx=$(COSIGN_EXPERIMENTAL=1 cosign verify-attestation --type spdx ${{ inputs.image }} | jq '.payload |= @base64d | .payload | fromjson | select( .predicateType=='https://spdx.dev/Document' ) | .predicate.Data | fromjson | .') >> $GITHUB_OUTPUT
+          echo "spdx=$(COSIGN_EXPERIMENTAL=1 cosign verify-attestation --type spdx ${{ inputs.image }} | jq '.payload |= @base64d | .payload | fromjson | select( .predicateType=='https://spdx.dev/Document' ) | .predicate.Data | fromjson | .") >> $GITHUB_OUTPUT
       - name: Scan image
         uses: anchore/scan-action@v3
         with:

--- a/.github/workflows/check-vulnerabilities.yaml
+++ b/.github/workflows/check-vulnerabilities.yaml
@@ -34,8 +34,8 @@ jobs:
         uses: anchore/scan-action@v3
         with:
           sbom: spdx.json
-      - name: Inspect action SARIF report
-        run: cat ${{ steps.scan.outputs.sarif }}
+          output: table
+          fail-build: false
       - name: Remove json 
         run: |
           rm spdx.json 


### PR DESCRIPTION
Add reusable workflow to check vulnerabilities for the given images.

This workflow will only work for keyless signed images.
See https://github.com/philips-software/docker-node/pull/133 for more info on this.

## TODO

Add some more documentation around this, but we first want to debug this and smoothen the workflows.. now the list of images is redundant which is fragile.
