### PR TITLE
Remove EXPERIMENTAL flag for keyless signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project uses the version of main tool as main version number .
 
 ## [Unreleased]
 
+- Cosign version 2.0
+- BREAKING when doing KEYLESS signing: 
+    - You need to acknowledge using a PUBLIC Rekor and Fulcio server when doing keyless signing. Set `public_transparancy_log` to `true`. Default is `false`.
+
+## v5.1.0
 - Remove experimental flag for keyless signing
 - Rename arguments to reflect multiple container registries.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project uses the version of main tool as main version number .
 
 ## [Unreleased]
 
+- Remove experimental flag for keyless signing
 - Rename arguments to reflect multiple container registries.
 
 ## v5.0.0

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Examples: Using explicit variables
 
 **Optional** Set to `true` when you want to use keyless signing with [SigStore's Rekor and Fulcio](https://blog.sigstore.dev/sigstore-ga-ddd6ba67894d).
 **Warning** This is a **PUBLIC** transparancy log, this means you will reveal information about your OCI images publically. **DO NOT USE THIS FOR PRIVATE IMAGES**.
+In order to make sure you understand a **PUBLIC** transparancy log is used, you need to set the `public_transparancy_log` argument to `true`.
 
 You can use `KEYLESS` to start using SigStore's Rekor and Fulcio together with GitHub OIDC. When set, you don't need to specify the three COSIGN Arguments.
 
@@ -235,7 +236,7 @@ Store the content of `cosign.pub`, `cosign.key` and the password in GitHub Secre
 Now you can verify the image f.e. `jeroenknoops/test-image:latest`:
 
 ```bash
-  $ cosign verify --key cosign.pub jeroenknoops/test-image:latest
+  $ cosign verify --insecure-ignore-tlog --key cosign.pub jeroenknoops/test-image:latest
 ```
 
 You will get a result when the image is valid.
@@ -276,8 +277,7 @@ Now you can verify the image f.e. `jeroenknoops/test-image:latest`:
 Keyless siging is still an expermental feature of cosign, so you need to set the flag.
 
 ```bash
-  $ export COSIGN_EXPERIMENTAL=1
-  $ cosign verify --key cosign.pub jeroenknoops/test-image:latest
+  $ cosign verify --insecure-ignore-tlog --key cosign.pub jeroenknoops/test-image:latest
 ```
 
 You will get a result when the image is valid.
@@ -337,7 +337,7 @@ the COSIGN environment variables. (see #sign how to generate the key-pair)
 Now you can verify the attestation for a certain docker-repo f.e. `jeroenknoops/test-image:latest`:
 
 ```bash
-  $ cosign verify-attestation --key cosign.pub jeroenknoops/test-image:latest | jq '.payload |= @base64d | .payload | fromjson | select(.predicateType=="https://slsa.dev/provenance/v0.2" ) | .'
+  $ cosign verify-attestation --insecure-ignore-tlog --key cosign.pub jeroenknoops/test-image:latest | jq '.payload |= @base64d | .payload | fromjson | select(.predicateType=="https://slsa.dev/provenance/v0.2" ) | .'
 ```
 
 This is nice, because you can see how and when the image was build, without downloading it!
@@ -393,7 +393,7 @@ the COSIGN environment variables. (see #sign how to generate the key-pair)
 Now you can verify the attestation for a certain docker-repo f.e. `jeroenknoops/test-image:latest`:
 
 ```bash
-$ cosign verify-attestation --key cosign.pub jeroenknoops/test-image:latest | jq '.payload |= @base64d | .payload | fromjson | select( .predicateType=="https://spdx.dev/Document" ) | .predicate.Data | fromjson | .'
+$ cosign verify-attestation --insecure-ignore-tlog --key cosign.pub jeroenknoops/test-image:latest | jq '.payload |= @base64d | .payload | fromjson | select( .predicateType=="https://spdx.dev/Document" ) | .predicate.Data | fromjson | .'
 ```
 
 #### With SLSA-Provenance and Software Bill of Material (SBOM) attached to Image:
@@ -425,8 +425,8 @@ the COSIGN environment variables. (see #sign how to generate the key-pair)
 Now you can verify the attestation for a certain docker-repo f.e. `jeroenknoops/test-image:latest`:
 
 ```bash
-$ cosign verify-attestation --key cosign.pub jeroenknoops/test-image:latest | jq '.payload |= @base64d | .payload | fromjson | select( .predicateType=="https://spdx.dev/Document" ) | .predicate.Data | fromjson | .'
-$ cosign verify-attestation --key cosign.pub jeroenknoops/test-image:latest | jq '.payload |= @base64d | .payload | fromjson | select(.predicateType=="https://slsa.dev/provenance/v0.2" ) | .'
+$ cosign verify-attestation --insecure-ignore-tlog --key cosign.pub jeroenknoops/test-image:latest | jq '.payload |= @base64d | .payload | fromjson | select( .predicateType=="https://spdx.dev/Document" ) | .predicate.Data | fromjson | .'
+$ cosign verify-attestation --insecure-ignore-tlog --key cosign.pub jeroenknoops/test-image:latest | jq '.payload |= @base64d | .payload | fromjson | select(.predicateType=="https://slsa.dev/provenance/v0.2" ) | .'
 ```
 
 This is nice, because you can see the SBOM of the image, without downloading it!

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
   sign:
     description: 'Sign image with Cosign. Requires COSIGN environment variables to be set. When used in combination with slsa-provenance / sbom it will also attach the results to the image.'
     required: false
+  public_transparancy_log:
+    description: 'Use PUBLIC Fulcio and Rekor services to store information'
+    required: true
+    default: false
   github_context:
     description: 'internal (do not set): the "github" context object in json'
     required: true
@@ -65,6 +69,7 @@ runs:
     SLSA_PROVENANCE: ${{ inputs.slsa-provenance }}
     SBOM: ${{ inputs.sbom }}
     SIGN: ${{ inputs.sign }}
+    PUBLIC_TRANSPARANCY_LOG: ${{ inputs.public_transparancy_log }}
     PUSH_ON_GIT_TAG: ${{ inputs.push-on-git-tag }}
     GITHUB_CONTEXT: ${{ inputs.github_context }}
     RUNNER_CONTEXT: ${{ inputs.runner_context }}

--- a/bin/install_cosign.sh
+++ b/bin/install_cosign.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-COSIGN_RELEASE=v1.14.0
+COSIGN_RELEASE=v2.0.0
 INSTALL_DIR=$HOME/.cosign
 
 RUNNER_OS=$(uname)
@@ -37,13 +37,13 @@ shaprog() {
   esac
 }
 
-bootstrap_version='v1.13.1'
-bootstrap_linux_amd64_sha='a50651a67b42714d6f1a66eb6773bf214dacae321f04323c0885f6a433051f95'
-bootstrap_linux_arm_sha='edc24d49459a73f54e78868a3540e1e54452ad2328c66e1eba8bcd78fcd349fc'
-bootstrap_linux_arm64_sha='a7a79a52c7747e2c21554cad4600e6c7130c0429017dd258f9c558d957fa9090'
-bootstrap_darwin_amd64_sha='1d164b8b1fcfef1e1870d809edbb9862afd5995cab63687a440b84cca5680ecf'
-bootstrap_darwin_arm64_sha='02bef878916be048fd7dcf742105639f53706a59b5b03f4e4eaccc01d05bc7ab'
-bootstrap_windows_amd64_sha='78a2774b68b995cc698944f6c235b1c93dcb6d57593a58a565ee7a56d64e4b85'
+bootstrap_version='v2.0.0'
+bootstrap_linux_amd64_sha='169a53594c437d53ffc401b911b7e70d453f5a2c1f96eb2a736f34f6356c4f2b'
+bootstrap_linux_arm_sha='189d56c9946decdaa272e1dccb47ae64009ea39ac0274cfea00507b9acb877c9'
+bootstrap_linux_arm64_sha='8132cb2fb99a4c60ba8e03b079e12462c27073028a5d08c07ecda67284e0c88d'
+bootstrap_darwin_amd64_sha='d2c8fc0edb42a1e9745da1c43a2928cee044f3b8a1b8df64088a384c7e6f5b5d'
+bootstrap_darwin_arm64_sha='9d7821e1c05da4b07513729cb00d1070c9a95332c66d90fa593ed77d8c72ca2a'
+bootstrap_windows_amd64_sha='e78e7464dc0eda1d6ec063ac2738f4d1418b19dd19f999aa37e1679d5d3af82e'
 cosign_executable_name=cosign
 
 trap "popd >/dev/null" EXIT
@@ -157,7 +157,7 @@ if [[ ${COSIGN_RELEASE} == ${bootstrap_version} ]]; then
   log_info "bootstrap version successfully verified and matches requested version so nothing else to do"
   exit 0
 fi
-semver='^v([0-9]+\.){0,2}(\*|[0-9]+)$'
+semver='^v([0-9]+\.){0,2}(\*|[0-9]+)(-?r?c?)(\.[0-9]+)$'
 if [[ ${COSIGN_RELEASE} =~ $semver ]]; then
   log_info "Custom cosign version '${COSIGN_RELEASE}' requested"
 else
@@ -197,7 +197,7 @@ if [[ $shaCustom != $shaBootstrap ]]; then
     RELEASE_COSIGN_PUB_KEY=https://raw.githubusercontent.com/sigstore/cosign/${COSIGN_RELEASE}/release/release-cosign.pub
   fi
   log_info "Using bootstrap cosign to verify signature of desired cosign version"
-  ./cosign verify-blob --key $RELEASE_COSIGN_PUB_KEY --signature ${desired_cosign_filename}.sig cosign_${COSIGN_RELEASE}
+  ./cosign verify-blob --insecure-ignore-tlog --key $RELEASE_COSIGN_PUB_KEY --signature ${desired_cosign_filename}.sig cosign_${COSIGN_RELEASE}
   rm cosign
   mv cosign_${COSIGN_RELEASE} cosign
   chmod +x cosign

--- a/bin/install_cosign.sh
+++ b/bin/install_cosign.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-COSIGN_RELEASE=v1.13.1
+COSIGN_RELEASE=v1.14.0
 INSTALL_DIR=$HOME/.cosign
 
 RUNNER_OS=$(uname)

--- a/container_digest.sh
+++ b/container_digest.sh
@@ -75,7 +75,6 @@ then
     echo 'Keyless signing'
     COSIGN_KEY_ARGUMENT=""
     COSIGN_PUB_ARGUMENT=""
-    export COSIGN_EXPERIMENTAL=1
   else
     echo 'Signing using COSIGN keys'
     COSIGN_KEY=$(mktemp /tmp/cosign.XXXXXXXXXX) || exit 1
@@ -113,7 +112,6 @@ then
     echo '```bash'
     if [ -n "${KEYLESS}" ]
     then
-      echo "export COSIGN_EXPERIMENTAL=1"
       echo "cosign verify $registry_url_prefix/$imagename@${containerdigest}"
     else
       echo "cosign verify --key cosign.pub $registry_url_prefix/$imagename@${containerdigest}"
@@ -177,7 +175,6 @@ then
       echo '```bash'
       if [ -n "${KEYLESS}" ]
       then
-        echo "export COSIGN_EXPERIMENTAL=1"
         echo "cosign verify-attestation --type slsaprovenance $registry_url_prefix/$imagename@${containerdigest} | jq '.payload |= @base64d | .payload | fromjson | select(.predicateType==\"https://slsa.dev/provenance/v0.2\" ) | .'"
         # TODO: Add tlog
       else
@@ -234,7 +231,6 @@ then
       echo '```bash'
       if [ -n "${KEYLESS}" ]
       then
-        echo "export COSIGN_EXPERIMENTAL=1"
         echo "cosign verify-attestation --type spdx $registry_url_prefix/$imagename@${containerdigest} | jq '.payload |= @base64d | .payload | fromjson | select( .predicateType==\"https://spdx.dev/Document\" ) | .predicate.Data | fromjson | .'"
         # TODO: Add tlog
       else

--- a/container_digest.sh
+++ b/container_digest.sh
@@ -73,6 +73,14 @@ then
   if [ -n "${KEYLESS}" ]
   then
     echo 'Keyless signing'
+    if [ "${PUBLIC_TRANSPARANCY_LOG}" == false ]
+    then
+        echo "---------------------------  ERROR --------------------------------"
+        echo "You want to use keyless signing without a public transparancy log."
+        echo "We do not support local REKOR and FULCIO servers at this moment."
+        echo "---------------------------  ERROR --------------------------------"
+        exit 1
+    fi
     COSIGN_KEY_ARGUMENT=""
     COSIGN_PUB_ARGUMENT=""
   else
@@ -84,8 +92,8 @@ then
     echo "${COSIGN_PRIVATE_KEY}" > "$COSIGN_KEY"
     echo "${COSIGN_PUBLIC_KEY}" > "$COSIGN_PUB"
 
-    COSIGN_KEY_ARGUMENT="--key $COSIGN_KEY"
-    COSIGN_PUB_ARGUMENT="--key $COSIGN_PUB"
+    COSIGN_KEY_ARGUMENT="--insecure-ignore-tlog --key $COSIGN_KEY"
+    COSIGN_PUB_ARGUMENT="--insecure-ignore-tlog --key $COSIGN_PUB"
   fi
   echo "Sign image"
 
@@ -114,7 +122,7 @@ then
     then
       echo "cosign verify $registry_url_prefix/$imagename@${containerdigest}"
     else
-      echo "cosign verify --key cosign.pub $registry_url_prefix/$imagename@${containerdigest}"
+      echo "cosign verify --insecure-ignore-tlog --key cosign.pub $registry_url_prefix/$imagename@${containerdigest}"
     fi
     echo '```'
     if [ -n "${KEYLESS}" ]
@@ -178,7 +186,7 @@ then
         echo "cosign verify-attestation --type slsaprovenance $registry_url_prefix/$imagename@${containerdigest} | jq '.payload |= @base64d | .payload | fromjson | select(.predicateType==\"https://slsa.dev/provenance/v0.2\" ) | .'"
         # TODO: Add tlog
       else
-        echo "cosign verify-attestation --key cosign.pub --type slsaprovenance $registry_url_prefix/$imagename@${containerdigest} | jq '.payload |= @base64d | .payload | fromjson | select(.predicateType==\"https://slsa.dev/provenance/v0.2\" ) | .'"
+        echo "cosign verify-attestation --insecure-ignore-tlog --key cosign.pub --type slsaprovenance $registry_url_prefix/$imagename@${containerdigest} | jq '.payload |= @base64d | .payload | fromjson | select(.predicateType==\"https://slsa.dev/provenance/v0.2\" ) | .'"
       fi
       echo '```'
       if [ -n "${KEYLESS}" ]
@@ -234,7 +242,7 @@ then
         echo "cosign verify-attestation --type spdx $registry_url_prefix/$imagename@${containerdigest} | jq '.payload |= @base64d | .payload | fromjson | select( .predicateType==\"https://spdx.dev/Document\" ) | .predicate.Data | fromjson | .'"
         # TODO: Add tlog
       else
-        echo "cosign verify-attestation --key cosign.pub --type spdx $registry_url_prefix/$imagename@${containerdigest} | jq '.payload |= @base64d | .payload | fromjson | select( .predicateType==\"https://spdx.dev/Document\" ) | .predicate.Data | fromjson | .'"
+        echo "cosign verify-attestation --insecure-ignore-tlog --key cosign.pub --type spdx $registry_url_prefix/$imagename@${containerdigest} | jq '.payload |= @base64d | .payload | fromjson | select( .predicateType==\"https://spdx.dev/Document\" ) | .predicate.Data | fromjson | .'"
       fi
       echo '```'
       if [ -n "${KEYLESS}" ]


### PR DESCRIPTION
EXPERIMENTAL flag is not necessary anymore in Cosign v2.0.0

See also: https://blog.sigstore.dev/cosign-2-0-released/

Current support:
- private signing (with public tlog) only with cosign Public and Private key.
- public signing (with public tlog) only in keyless mode.

Support for keyless signing with private Rekor / Fulcio is not supported yet.