### PR TITLE
use alltags argument instead of docker inspect to get all tags.

### DIFF
--- a/container_digest.sh
+++ b/container_digest.sh
@@ -54,7 +54,9 @@ echo "container-digest=${containerdigest}" >> "$GITHUB_OUTPUT"
 echo "--------------------------------------------------------------------------------------------"
 
 echo "Getting tags"
-containertags=$(docker inspect "$registry_url_prefix"/"$imagename":"$basetag" --format '{{ join .RepoTags "\n" }}' | sed 's/.*://' | paste -s -d ',' -)
+# slsa-provenance expects tags with a comma in between. This can be done with the docker inspect method, but in some cases this will end up incorrect. F.e. when using docker-ci-scripts to generate the docker-ci-script container.
+containertags="${alltags// /,}"
+
 echo "found: ${containertags}"
 echo "container-tags=${containertags}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
This was causing a bug when creating docker-ci-scripts container with docker-ci-scripts. The temporary build docker-ci-script has a temporary tag, without being pushed. This will end-up in the list of tags. SLSA-provenance will fail because it cannot retrieve the manifest

See <https://github.com/philips-software/docker-ci-scripts/actions/runs/3989366117/jobs/6841702112#step:4:531>

```
Get tags:
found: 022c3e5c1d8e4e19bf8263aaadd73102,main
```